### PR TITLE
Prepare release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [1.0.1] - 2020-11-12
+### Added
+- Se soluciona error 500 cuando una transacción era rechazada [PR 5](https://github.com/TransbankDevelopers/transbank-plugin-prestashop-webpay-rest/pull/5)
+- Se mejora documentación de instalación [PR 4](https://github.com/TransbankDevelopers/transbank-plugin-prestashop-webpay-rest/pull/4)
+
 ## [1.0.0] - 2020-11-12
 ### Added
 - Primer release


### PR DESCRIPTION
You can see the full diff [here](https://github.com/TransbankDevelopers/transbank-plugin-prestashop-webpay-rest/compare/1.0.0...chore/prepare-release-1.0.1)