### PR TITLE
Fix/sonarcloud bugs

### DIFF
--- a/webpay/controllers/front/oneclickinscription.php
+++ b/webpay/controllers/front/oneclickinscription.php
@@ -52,7 +52,7 @@ class WebPayOneclickInscriptionModuleFrontController extends BaseModuleFrontCont
             $saved = $ins->save();
             if (!$saved) {
                 $this->logError('Could not create record on transbank_inscriptions database');
-                return $this->setErrorTemplate(['error' => 'No se pudo crear la transacción en la tabla transbank_inscriptions']);
+                $this->setErrorTemplate(['error' => 'No se pudo crear la transacción en la tabla transbank_inscriptions']);
             }
             $this->setRedirectionTemplate($resp, $this->getOrderTotalRound($cart));
         } else {

--- a/webpay/controllers/front/oneclickinscriptionvalidate.php
+++ b/webpay/controllers/front/oneclickinscriptionvalidate.php
@@ -21,7 +21,7 @@ class WebPayOneclickInscriptionValidateModuleFrontController extends BaseModuleF
         $tbkOrdenCompra = isset($data["TBK_ORDEN_COMPRA"]) ? $data['TBK_ORDEN_COMPRA'] : null;
 
         if ($tbkOrdenCompra && $tbkSessionId && !$token){
-            return $this->setErrorTemplate(['error' => 'Timeout Error.']);
+            $this->setErrorTemplate(['error' => 'Timeout Error.']);
         }
 
         //validar si se registro la tarjeta correctamente correctamente
@@ -34,7 +34,7 @@ class WebPayOneclickInscriptionValidateModuleFrontController extends BaseModuleF
         if (isset($tbkOrdenCompra)) {//se abandono la inscripcion al haber presionado la opción 'Abandonar y volver al comercio'
             $ins->status = TransbankInscriptions::STATUS_FAILED;
             $ins->save();
-            return $this->setErrorTemplate(['error' => 'Inscripción abortada desde el formulario. Puedes reintentar la inscripción. ']);//.', token: '.$token.', tbkSessionId: '.$tbkSessionId.', tbkOrdenCompra: '.$tbkOrdenCompra
+            $this->setErrorTemplate(['error' => 'Inscripción abortada desde el formulario. Puedes reintentar la inscripción. ']);//.', token: '.$token.', tbkSessionId: '.$tbkSessionId.', tbkOrdenCompra: '.$tbkOrdenCompra
         }
 
         //registro correcto

--- a/webpay/controllers/front/oneclickpaymentvalidate.php
+++ b/webpay/controllers/front/oneclickpaymentvalidate.php
@@ -100,7 +100,7 @@ class WebPayOneclickPaymentValidateModuleFrontController extends PaymentModuleFr
 
         if (!$saved) {
             $this->logOneclickPaymentCrearTxBdError($inscriptionId, $transaction);
-            return $this->setPaymentErrorPage('No se pudo guardar en base de datos el resultado de la transacción ');
+            $this->setPaymentErrorPage('No se pudo guardar en base de datos el resultado de la transacción ');
         }
 
         $this->logOneclickPaymentAntesAutorizarTx($ins->username, $ins->tbk_token, $parentBuyOrder, $childBuyOrder, $amount);

--- a/webpay/controllers/front/webpaypluspayment.php
+++ b/webpay/controllers/front/webpaypluspayment.php
@@ -112,7 +112,7 @@ class WebPayWebpayplusPaymentModuleFrontController extends BaseModuleFrontContro
         $saved = $transaction->save();
         if (!$saved) {
             $this->logWebpayPlusDespuesCrearTxEnTablaError($transaction);
-            return $this->setErrorTemplate(['error' => 'No se pudo crear la transacción en la tabla webpay_transactions']);
+            $this->setErrorTemplate(['error' => 'No se pudo crear la transacción en la tabla webpay_transactions']);
         }
         return $transaction;
     }

--- a/webpay/controllers/front/webpaypluspaymentvalidate.php
+++ b/webpay/controllers/front/webpaypluspaymentvalidate.php
@@ -139,7 +139,7 @@ class WebPayWebpayplusPaymentValidateModuleFrontController extends PaymentModule
         $amount = $this->getOrderTotal($cart);
         if ($webpayTransaction->amount != $this->getOrderTotalRound($cart)) {
             $this->logWebpayPlusCommitTxCarroManipuladoError($token, $webpayTransaction);
-            return $this->handleCartManipulated($token, $webpayTransaction);
+            $this->handleCartManipulated($token, $webpayTransaction);
         }
 
         $transbankSdkWebpay = WebpayPlusFactory::create();

--- a/webpay/controllers/front/webpaypluspaymentvalidate.php
+++ b/webpay/controllers/front/webpaypluspaymentvalidate.php
@@ -50,7 +50,7 @@ class WebPayWebpayplusPaymentValidateModuleFrontController extends PaymentModule
             else if ($webpayTransaction->status != TransbankWebpayRestTransaction::STATUS_INITIALIZED) {
                 $this->logWebpayPlusCommitTxNoInicializadoError($tokenWs, $webpayTransaction);
                 $msg = 'Esta compra se encuentra en estado rechazado o cancelado y no se puede aceptar el pago';
-                return $this->setPaymentErrorPage($msg);
+                $this->setPaymentErrorPage($msg);
             }
 
             if ($this->getTransactionApprovedByCartId($webpayTransaction->cart_id) && !isset($_GET['final'])) {
@@ -58,7 +58,7 @@ class WebPayWebpayplusPaymentValidateModuleFrontController extends PaymentModule
                 $msg = 'Otra transacción de este carro de compras ya fue aprobada. Se rechazo este pago para no generar un cobro duplicado';
                 $webpayTransaction->status = TransbankWebpayRestTransaction::STATUS_FAILED;
                 $webpayTransaction->save();
-                return $this->setPaymentErrorPage($msg);
+                $this->setPaymentErrorPage($msg);
             }
 
             $this->processPayment($tokenWs, $webpayTransaction, $cart);
@@ -74,7 +74,7 @@ class WebPayWebpayplusPaymentValidateModuleFrontController extends PaymentModule
             $this->logWebpayPlusRetornandoDesdeTbkFujo3TxError($tbktoken, $webpayTransaction);
             $webpayTransaction->save();
             $msg = 'Transacción abortada desde el formulario de pago. Puedes reintentar el pago. ';
-            return $this->setPaymentErrorPage($msg);
+            $this->setPaymentErrorPage($msg);
         }
         else if (isset($tokenWs) && isset($tbktoken)) {//Flujo 4 => El pago es inválido.
             $this->logWebpayPlusRetornandoDesdeTbkFujo4Error($tokenWs, $tbktoken);
@@ -82,7 +82,7 @@ class WebPayWebpayplusPaymentValidateModuleFrontController extends PaymentModule
             $msg = 'Al parecer ocurrió un error durante el proceso de pago. Puedes volver a intentar. ';
             $webpayTransaction->status = TransbankWebpayRestTransaction::STATUS_FAILED;
             $webpayTransaction->save();
-            return $this->setPaymentErrorPage($msg);
+            $this->setPaymentErrorPage($msg);
         }
         
     }
@@ -214,7 +214,7 @@ class WebPayWebpayplusPaymentValidateModuleFrontController extends PaymentModule
         cargo será realizado en su tarjeta. Por favor, reintente el pago.';
         $message = 'Carro ha sido manipulado durante el proceso de pago';
         $this->updateTransactionStatus($webpayTransaction, TransbankWebpayRestTransaction::STATUS_FAILED, json_encode(['error' => $message]));
-        return $this->setPaymentErrorPage($error);
+        $this->setPaymentErrorPage($error);
     }
 
     /**

--- a/webpay/src/Controller/BaseModuleFrontController.php
+++ b/webpay/src/Controller/BaseModuleFrontController.php
@@ -121,8 +121,8 @@ class BaseModuleFrontController extends ModuleFrontController
     }
 
     protected function loadCartFromCookie(){
-        $this->$context->cart = new Cart($this->context->cookie->webpay_cart_id);
-        return $this->$context->cart;
+        $this->context->cart = new Cart($this->context->cookie->webpay_cart_id);
+        return $this->context->cart;
     }
 
     protected function getUserIdFromCookie(){


### PR DESCRIPTION
Fixed SonarCloud bugs:
Remove not needed output returns on template functions on the next files:
-webpay/controllers/front/oneclickinscription.php
-webpay/controllers/front/oneclickinscriptionvalidate.php
-webpay/controllers/front/oneclickpaymentvalidate.php
-webpay/controllers/front/webpaypluspayment.php
-webpay/controllers/front/webpaypluspaymentvalidate.php
-webpay/controllers/front/webpaypluspaymentvalidate.php

Fix data flow on a variable that was not initialized:
-webpay/src/Controller/BaseModuleFrontController.php

Evidences:
Onclick:
![test-onclick](https://github.com/TransbankDevelopers/transbank-plugin-prestashop-webpay-rest/assets/96386143/e7e9b94c-ab87-4be5-9b68-7837232d9c14)

Error on form:
![Screenshot 2023-07-06 190114](https://github.com/TransbankDevelopers/transbank-plugin-prestashop-webpay-rest/assets/96386143/c9cd3405-9ed0-4eb7-9b80-f9f5527c9605)

Happy purchase:
![Screenshot 2023-07-06 190217](https://github.com/TransbankDevelopers/transbank-plugin-prestashop-webpay-rest/assets/96386143/23707f19-6ff8-4bfc-9542-72817bfc65e2)


