### PR TITLE
fix: no show transaction view

### DIFF
--- a/webpay/src/Core/Grid/Column/Type/CustomLinkColumn.php
+++ b/webpay/src/Core/Grid/Column/Type/CustomLinkColumn.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace PrestaShop\Module\WebpayPlus\Core\Grid\Column\Type;
+
+use PrestaShop\PrestaShop\Core\Grid\Column\AbstractColumn;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class CustomLinkColumn extends AbstractColumn
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'custom_link';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+        $resolver
+            ->setDefaults([
+                'icon' => null,
+                'route_fragment' => null,
+                'button_template' => false,
+                'color_template' => 'primary',
+                'color_template_field' => null,
+            ])
+            ->setRequired([
+                'field',
+                'route',
+                'route_param_name',
+                'route_param_field',
+            ])
+            ->setDefined([
+                'icon',
+                'target',
+            ])
+            ->setAllowedTypes('field', ['string', 'null'])
+            ->setAllowedTypes('icon', ['string', 'null'])
+            ->setAllowedTypes('target', ['string', 'null'])
+            ->setAllowedTypes('color_template_field', ['string', 'null'])
+            ->setAllowedTypes('sortable', 'bool')
+            ->setAllowedTypes('route', 'string')
+            ->setAllowedTypes('route_fragment', ['string', 'null'])
+            ->setAllowedTypes('route_param_name', 'string')
+            ->setAllowedTypes('route_param_field', ['string', 'null'])
+            ->setAllowedTypes('clickable', 'bool')
+            ->setAllowedValues('color_template', [
+                'primary',
+                'secondary',
+                'success',
+                'danger',
+                'warning',
+                'info',
+            ])
+            ->setAllowedValues('button_template', [
+                false,
+                'outline',
+                'normal',
+            ])
+        ;
+    }
+}

--- a/webpay/src/Grid/TransactionsEnvironmentChoiceProvider.php
+++ b/webpay/src/Grid/TransactionsEnvironmentChoiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PrestaShop\Module\WebpayPlus\Grid;
+
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShop\Module\WebpayPlus\Model\TransbankWebpayRestTransaction;
+use Transbank\Webpay\Options;
+
+class TransactionsEnvironmentChoiceProvider implements FormChoiceProviderInterface
+{
+    public function getChoices()
+    {
+        return [
+            'Producción' => Options::ENVIRONMENT_PRODUCTION,
+            'Integración' => Options::ENVIRONMENT_INTEGRATION
+        ];
+    }
+}

--- a/webpay/src/Grid/TransactionsGridDefinitionFactory.php
+++ b/webpay/src/Grid/TransactionsGridDefinitionFactory.php
@@ -39,35 +39,32 @@ final class TransactionsGridDefinitionFactory extends AbstractFilterableGridDefi
         $gridColumns = $this->getGridColumnsData();
         $columnCollection = new ColumnCollection();
 
-        foreach ($gridColumns as $key => $columnName) {
-            if ($key === 'actions') {
-                $columnCollection->add((new ActionColumn($key))
-                        ->setName($columnName)
+        $columnActions = [
+            'actions' => function ($key, $columnName) use ($columnCollection) {
+                $columnCollection->add(
+                    (new ActionColumn($key))->setName($columnName)
                 );
-                continue;
-            }
-
-            if ($key === 'status') {
-                $columnCollection->add((new ColorColumn($key))
+            },
+            'status' => function ($key, $columnName) use ($columnCollection) {
+                $columnCollection->add(
+                    (new ColorColumn($key))
                         ->setName($columnName)
                         ->setOptions([
                             'field' => $key,
                             'color_field' => 'status_color',
                         ])
                 );
-                continue;
-            }
-
-            if ($key === 'created_at') {
-                $columnCollection->add((new DateTimeColumn($key))
+            },
+            'created_at' => function ($key, $columnName) use ($columnCollection) {
+                $columnCollection->add(
+                    (new DateTimeColumn($key))
                         ->setName($columnName)
                         ->setOptions(['field' => $key])
                 );
-                continue;
-            }
-
-            if ($key === 'order_id') {
-                $columnCollection->add((new CustomLinkColumn($key))
+            },
+            'order_id' => function ($key, $columnName) use ($columnCollection) {
+                $columnCollection->add(
+                    (new CustomLinkColumn($key))
                         ->setName($columnName)
                         ->setOptions([
                             'field' => $key,
@@ -76,13 +73,19 @@ final class TransactionsGridDefinitionFactory extends AbstractFilterableGridDefi
                             'route_param_field' => $key,
                         ])
                 );
-                continue;
             }
+        ];
 
-            $columnCollection->add((new DataColumn($key))
-                    ->setName($columnName)
-                    ->setOptions(['field' => $key])
-            );
+        foreach ($gridColumns as $key => $columnName) {
+            if (isset($columnActions[$key])) {
+                $columnActions[$key]($key, $columnName);
+            } else {
+
+                $columnCollection->add((new DataColumn($key))
+                        ->setName($columnName)
+                        ->setOptions(['field' => $key])
+                );
+            }
         }
 
         return $columnCollection;
@@ -93,17 +96,15 @@ final class TransactionsGridDefinitionFactory extends AbstractFilterableGridDefi
         $gridColumns = $this->getGridColumnsData();
         $filterCollection = new FilterCollection();
 
-        foreach ($gridColumns as $key => $columnName) {
-            if ($key === 'amount') {
+        $filterActions = [
+            'amount' => function ($key) use ($filterCollection) {
                 $filterCollection->add(
                     (new Filter($key, NumberType::class))
                         ->setAssociatedColumn($key)
                         ->setTypeOptions(['required' => false])
                 );
-                continue;
-            }
-
-            if ($key === 'status') {
+            },
+            'status' => function ($key) use ($filterCollection) {
                 $filterCollection->add(
                     (new Filter($key, ChoiceType::class))
                         ->setAssociatedColumn($key)
@@ -112,19 +113,15 @@ final class TransactionsGridDefinitionFactory extends AbstractFilterableGridDefi
                             'required' => false
                         ])
                 );
-                continue;
-            }
-
-            if ($key === 'created_at') {
+            },
+            'created_at' => function ($key) use ($filterCollection) {
                 $filterCollection->add(
                     (new Filter($key, DateRangeType::class))
                         ->setAssociatedColumn($key)
                         ->setTypeOptions(['required' => false])
                 );
-                continue;
-            }
-
-            if ($key === 'actions') {
+            },
+            'actions' => function ($key) use ($filterCollection) {
                 $filterCollection->add(
                     (new Filter($key, SearchAndResetType::class))
                         ->setAssociatedColumn($key)
@@ -136,14 +133,19 @@ final class TransactionsGridDefinitionFactory extends AbstractFilterableGridDefi
                             'redirect_route' => 'ps_controller_webpay_transaction_list',
                         ])
                 );
-                continue;
             }
+        ];
 
-            $filterCollection->add(
-                (new Filter($key, TextType::class))
-                    ->setAssociatedColumn($key)
-                    ->setTypeOptions(['required' => false])
-            );
+        foreach ($gridColumns as $key => $columnName) {
+            if (isset($filterActions[$key])) {
+                $filterActions[$key]($key);
+            } else {
+                $filterCollection->add(
+                    (new Filter($key, TextType::class))
+                        ->setAssociatedColumn($key)
+                        ->setTypeOptions(['required' => false])
+                );
+            }
         }
 
         return $filterCollection;

--- a/webpay/src/Grid/TransactionsGridDefinitionFactory.php
+++ b/webpay/src/Grid/TransactionsGridDefinitionFactory.php
@@ -114,6 +114,16 @@ final class TransactionsGridDefinitionFactory extends AbstractFilterableGridDefi
                         ])
                 );
             },
+            'product' => function ($key) use ($filterCollection) {
+                $filterCollection->add(
+                    (new Filter($key, ChoiceType::class))
+                        ->setAssociatedColumn($key)
+                        ->setTypeOptions([
+                            'choices' => (new TransactionsProductChoiceProvider())->getChoices(),
+                            'required' => false
+                        ])
+                );
+            },
             'created_at' => function ($key) use ($filterCollection) {
                 $filterCollection->add(
                     (new Filter($key, DateRangeType::class))

--- a/webpay/src/Grid/TransactionsGridDefinitionFactory.php
+++ b/webpay/src/Grid/TransactionsGridDefinitionFactory.php
@@ -114,6 +114,16 @@ final class TransactionsGridDefinitionFactory extends AbstractFilterableGridDefi
                         ])
                 );
             },
+            'environment' => function ($key) use ($filterCollection) {
+                $filterCollection->add(
+                    (new Filter($key, ChoiceType::class))
+                        ->setAssociatedColumn($key)
+                        ->setTypeOptions([
+                            'choices' => (new TransactionsEnvironmentChoiceProvider())->getChoices(),
+                            'required' => false
+                        ])
+                );
+            },
             'product' => function ($key) use ($filterCollection) {
                 $filterCollection->add(
                     (new Filter($key, ChoiceType::class))

--- a/webpay/src/Grid/TransactionsGridDefinitionFactory.php
+++ b/webpay/src/Grid/TransactionsGridDefinitionFactory.php
@@ -2,7 +2,7 @@
 
 namespace PrestaShop\Module\WebpayPlus\Grid;
 
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\LinkColumn;
+use PrestaShop\Module\WebpayPlus\Core\Grid\Column\Type\CustomLinkColumn;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractFilterableGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
@@ -67,7 +67,7 @@ final class TransactionsGridDefinitionFactory extends AbstractFilterableGridDefi
             }
 
             if ($key === 'order_id') {
-                $columnCollection->add((new LinkColumn($key))
+                $columnCollection->add((new CustomLinkColumn($key))
                         ->setName($columnName)
                         ->setOptions([
                             'field' => $key,

--- a/webpay/src/Grid/TransactionsProductChoiceProvider.php
+++ b/webpay/src/Grid/TransactionsProductChoiceProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PrestaShop\Module\WebpayPlus\Grid;
+
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShop\Module\WebpayPlus\Model\TransbankWebpayRestTransaction;
+
+class TransactionsProductChoiceProvider implements FormChoiceProviderInterface
+{
+    public function getChoices()
+    {
+        return [
+            'Webpay Plus' => TransbankWebpayRestTransaction::PRODUCT_WEBPAY_PLUS,
+            'Webpay Oneclick' => TransbankWebpayRestTransaction::PRODUCT_WEBPAY_ONECLICK
+        ];
+    }
+}

--- a/webpay/src/Grid/TransactionsQueryBuilder.php
+++ b/webpay/src/Grid/TransactionsQueryBuilder.php
@@ -120,7 +120,7 @@ final class TransactionsQueryBuilder extends AbstractDoctrineQueryBuilder
 
         $queryBuilder->select('order_id, response_code, (' . $caseVCI . ') as vci, amount, iso_code, card_number, token,
          (' . $caseStatus . ') as status, (' . $caseEnvironment . ') as environment,
-         (' . $caseColor . ') as status_color, (' . $caseProduct . ') as product');
+         (' . $caseColor . ') as status_color, (' . $caseProduct . ') as product, created_at');
 
         return $queryBuilder;
     }

--- a/webpay/views/PrestaShop/Admin/Common/Grid/Columns/Content/custom_link.html.twig
+++ b/webpay/views/PrestaShop/Admin/Common/Grid/Columns/Content/custom_link.html.twig
@@ -1,0 +1,74 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{% if column.options.color_template_field is not empty and record[column.options.color_template_field] is defined %}
+  {% set color = record[column.options.color_template_field] %}
+{% else %}
+  {% set color = column.options.color_template %}
+{% endif %}
+{% set class = "text-" ~ color %}
+
+{% if column.options.button_template %}
+  {% set style = column.options.button_template %}
+  {% if style == 'normal' %}
+    {% set class = "btn btn-" ~ color %}
+  {% elseif style == 'outline' %}
+    {% set class = "btn btn-outline-" ~ color %}
+  {% endif %}
+{% endif %}
+
+{% set class = (class ~ ' ' ~ column.options.attr.class|default(''))|trim %}
+
+{% block link %}
+{% if record[column.options.route_param_field] is not null %}
+    <a
+    class="{{ class }} text-nowrap"
+    href="{{ path(column.options.route, { (column.options.route_param_name) : record[column.options.route_param_field], _fragment : column.options.route_fragment }) }}"
+    {% if column.options.target is defined %}
+        target="{{ column.options.target }}"
+    {% endif %}
+    {# Add all attributes which are not class #}
+    {%- for attrname, attrvalue in column.options.attr -%}
+        {% if attrname != 'class' %}
+        {{- " " -}}
+        {% if attrvalue is formview %}
+            {{- attrname }}="{{ form_row(attrvalue)|e('html_attr') }}"
+        {% elseif attrvalue is form %}
+        {{- attrname }}="{{ form_row(attrvalue.createView())|e('html_attr') }}"
+        {% else %}
+            {{- attrname }}="{{ attrvalue }}"
+        {% endif %}
+        {% endif %}
+    {%- endfor -%}
+    >
+    {% if column.options.icon is defined and column.options.icon is not empty %}
+        <i class="material-icons">{{ column.options.icon }}</i>
+    {% endif %}
+    {{ record[column.options.field] }}
+    </a>
+{% else %}
+  -
+{% endif %}
+{% endblock %}

--- a/webpay/views/PrestaShop/Admin/Common/Grid/Columns/Content/custom_link.html.twig
+++ b/webpay/views/PrestaShop/Admin/Common/Grid/Columns/Content/custom_link.html.twig
@@ -1,28 +1,3 @@
-{#**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.md.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
-
 {% if column.options.color_template_field is not empty and record[column.options.color_template_field] is defined %}
   {% set color = record[column.options.color_template_field] %}
 {% else %}

--- a/webpay/views/PrestaShop/Admin/Common/Grid/Columns/Content/custom_link.html.twig
+++ b/webpay/views/PrestaShop/Admin/Common/Grid/Columns/Content/custom_link.html.twig
@@ -24,7 +24,7 @@
     {% if column.options.target is defined %}
         target="{{ column.options.target }}"
     {% endif %}
-    {# Add all attributes which are not class #}
+
     {%- for attrname, attrvalue in column.options.attr -%}
         {% if attrname != 'class' %}
         {{- " " -}}


### PR DESCRIPTION
This PR resolves an issue that prevented the Transactions view from being displayed in the plugin settings menu.

## Tests

### Show Transaction view
![image](https://github.com/user-attachments/assets/fc77556e-573c-4a0a-b783-2325bbf9959e)

### Filter data
![image](https://github.com/user-attachments/assets/60b27ce0-0f24-4889-9041-47449a0271c3)
![image](https://github.com/user-attachments/assets/58ccbf83-b66b-44b7-b5ff-b644565fb15d)

