### PR TITLE
feat: add grid compatibility for prestashop 1.7.8

### DIFF
--- a/webpay/src/Grid/TransactionsGridDefinitionFactory.php
+++ b/webpay/src/Grid/TransactionsGridDefinitionFactory.php
@@ -5,7 +5,7 @@ namespace PrestaShop\Module\WebpayPlus\Grid;
 use PrestaShop\Module\WebpayPlus\Grid\Column\Type\CustomLinkColumn;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractFilterableGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
@@ -16,7 +16,7 @@ use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ColorColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\ColorColumn;
 use PrestaShop\Module\WebpayPlus\Grid\TransactionsStatusChoiceProvider;
 
 

--- a/webpay/views/PrestaShop/Admin/Common/Grid/Columns/Content/custom_link.html.twig
+++ b/webpay/views/PrestaShop/Admin/Common/Grid/Columns/Content/custom_link.html.twig
@@ -6,7 +6,6 @@
     class="{{ class }} text-nowrap"
     href="{{ path(column.options.route, { (column.options.route_param_name): record[column.options.route_param_field], _fragment: column.options.route_fragment }) }}"
     {% include '@PrestaShop/Admin/Common/Grid/Columns/Content/_target.html.twig' %}
-    {% include '@PrestaShop/Admin/Common/Grid/Columns/Content/_attr.html.twig' %}
     >
     {% include '@PrestaShop/Admin/Common/Grid/Columns/Content/_icon.html.twig' %}
     {{ record[column.options.field] }}


### PR DESCRIPTION
This PR add grid compatibility for prestashop 1.7.8.x

## Tests
### Prestashop 1.7.8.x
![image](https://github.com/user-attachments/assets/c2b9df7c-4fbf-403a-8119-e9533e4016d7)

### Prestashop 8.x
![image](https://github.com/user-attachments/assets/b001f235-5d90-4141-a4d3-3f0965a05327)

