### PR TITLE
feat: change the password type for apikey field

### DIFF
--- a/webpay/src/Form/OneclickDataConfiguration.php
+++ b/webpay/src/Form/OneclickDataConfiguration.php
@@ -58,7 +58,10 @@ final class OneclickDataConfiguration implements DataConfigurationInterface
         $this->configuration->set(static::ONECLICK_ACTIVE, $configuration['form_oneclick_active']);
         $this->configuration->set(static::ONECLICK_MALL_COMMERCE_CODE, $configuration['form_oneclick_mall_commerce_code']);
         $this->configuration->set(static::ONECLICK_CHILD_COMMERCE_CODE, $configuration['form_oneclick_child_commerce_code']);
-        $this->configuration->set(static::ONECLICK_API_KEY, $configuration['form_oneclick_api_key']);
+
+        if (!empty($configuration['form_oneclick_api_key'])) {
+            $this->configuration->set(static::ONECLICK_API_KEY, $configuration['form_oneclick_api_key']);
+        }
         $this->configuration->set(static::ONECLICK_ENVIRONMENT, $configuration['form_oneclick_environment']);
         $this->configuration->set(static::ONECLICK_DEFAULT_ORDER_STATE_ID_AFTER_PAYMENT, $configuration['form_oneclick_order_after_payment']);
         return [];

--- a/webpay/src/Form/OneclickType.php
+++ b/webpay/src/Form/OneclickType.php
@@ -11,6 +11,7 @@ use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use PrestaShop\PrestaShop\Adapter\Configuration;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -69,13 +70,14 @@ class OneclickType extends TranslatorAwareType
                     new Length(['min' => 12, 'max' => 12]),
                 ]
             ])
-            ->add('form_oneclick_api_key', TextType::class, [
+            ->add('form_oneclick_api_key', PasswordType::class, [
                 'label' => $this->trans('API Key (llave secreta)', 'Modules.WebpayPlus.Admin'),
                 'error_bubbling' => true,
+                'required' => false,
                 'constraints' => [
-                    new NotBlank(),
                     new Length(['min' => 12]),
-                ]
+                ],
+                'help' => $this->trans('Si no deseas cambiar el API Key, deja este campo vacío.', 'Modules.WebpayPlus.Admin'),
             ])
             ->add('form_oneclick_order_after_payment', ChoiceType::class, [
                 'label' => $this->trans('Estado Pago Aceptado', 'Modules.WebpayPlus.Admin'),
@@ -86,6 +88,6 @@ class OneclickType extends TranslatorAwareType
             ])
             ->add('oneclick_form_save_button', SubmitType::class, ['label' => $this->trans('Save', 'Modules.WebpayPlus.Admin')])
             ->add('oneclick_form_reset_button', SubmitType::class, ['label' => $this->trans('Reset', 'Modules.WebpayPlus.Admin')])
-            ;
+        ;
     }
 }

--- a/webpay/src/Form/OneclickType.php
+++ b/webpay/src/Form/OneclickType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;

--- a/webpay/src/Form/OneclickType.php
+++ b/webpay/src/Form/OneclickType.php
@@ -53,6 +53,7 @@ class OneclickType extends TranslatorAwareType
                     $this->trans('No', 'Modules.WebpayPlus.Admin') => Options::DEFAULT_INTEGRATION_TYPE,
                     $this->trans('Si', 'Modules.WebpayPlus.Admin') => Options::ENVIRONMENT_PRODUCTION,
                 ],
+                'help' => $this->trans('Cuando no está activado el modo producción, se utilizarán las claves predeterminadas del entorno de pruebas.', 'Modules.WebpayPlus.Admin'),
             ])
             ->add('form_oneclick_mall_commerce_code', TextType::class, [
                 'label' => $this->trans('Código de Comercio Mall', 'Modules.WebpayPlus.Admin'),

--- a/webpay/src/Form/WebpayPlusDataConfiguration.php
+++ b/webpay/src/Form/WebpayPlusDataConfiguration.php
@@ -54,7 +54,11 @@ final class WebpayPlusDataConfiguration implements DataConfigurationInterface
     {
         $this->configuration->set(static::WEBPAY_ACTIVE, $configuration['form_webpay_active']);
         $this->configuration->set(static::WEBPAY_STOREID, $configuration['form_webpay_commerce_code']);
-        $this->configuration->set(static::WEBPAY_API_KEY_SECRET, $configuration['form_webpay_api_key']);
+
+        if (!empty($configuration['form_webpay_api_key'])) {
+            $this->configuration->set(static::WEBPAY_API_KEY_SECRET, $configuration['form_webpay_api_key']);
+        }
+
         $this->configuration->set(static::WEBPAY_ENVIRONMENT, $configuration['form_webpay_environment']);
         $this->configuration->set(static::WEBPAY_DEFAULT_ORDER_STATE_ID_AFTER_PAYMENT, $configuration['form_webpay_order_after_payment']);
 

--- a/webpay/src/Form/WebpayPlusType.php
+++ b/webpay/src/Form/WebpayPlusType.php
@@ -11,6 +11,7 @@ use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use PrestaShop\PrestaShop\Adapter\Configuration;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -61,13 +62,14 @@ class WebpayPlusType extends TranslatorAwareType
                     new Length(['min' => 12, 'max' => 12]),
                 ]
             ])
-            ->add('form_webpay_api_key', TextType::class, [
+            ->add('form_webpay_api_key', PasswordType::class, [
                 'label' => $this->trans('API Key (llave secreta)', 'Modules.WebpayPlus.Admin'),
                 'error_bubbling' => true,
+                'required' => false,
                 'constraints' => [
-                    new NotBlank(),
                     new Length(['min' => 12]),
-                ]
+                ],
+                'help' => $this->trans('Si no deseas cambiar el API Key, deja este campo vacío.', 'Modules.WebpayPlus.Admin'),
             ])
             ->add('form_webpay_order_after_payment', ChoiceType::class, [
                 'label' => $this->trans('Estado Pago Aceptado', 'Modules.WebpayPlus.Admin'),
@@ -78,6 +80,6 @@ class WebpayPlusType extends TranslatorAwareType
             ])
             ->add('webpay_plus_form_save_button', SubmitType::class, ['label' => $this->trans('Save', 'Modules.WebpayPlus.Admin')])
             ->add('webpay_plus_form_reset_button', SubmitType::class, ['label' => $this->trans('Reset', 'Modules.WebpayPlus.Admin')])
-            ;
+        ;
     }
 }

--- a/webpay/src/Form/WebpayPlusType.php
+++ b/webpay/src/Form/WebpayPlusType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;

--- a/webpay/src/Form/WebpayPlusType.php
+++ b/webpay/src/Form/WebpayPlusType.php
@@ -53,6 +53,7 @@ class WebpayPlusType extends TranslatorAwareType
                     $this->trans('No', 'Modules.WebpayPlus.Admin') => Options::DEFAULT_INTEGRATION_TYPE,
                     $this->trans('Si', 'Modules.WebpayPlus.Admin') => Options::ENVIRONMENT_PRODUCTION,
                 ],
+                'help' => $this->trans('Cuando no está activado el modo producción, se utilizarán las claves predeterminadas del entorno de pruebas.', 'Modules.WebpayPlus.Admin'),
             ])
             ->add('form_webpay_commerce_code', TextType::class, [
                 'label' => $this->trans('Código de Comercio', 'Modules.WebpayPlus.Admin'),


### PR DESCRIPTION
This PR change the API key input to password type in Webpay and Oneclick config view.

## Test

### Webpay Configuration
![image](https://github.com/user-attachments/assets/84cb0ccb-71ed-4887-aaad-23c1239069b9)

### Webpay Oneclick
![image](https://github.com/user-attachments/assets/05762b32-2269-4178-8355-4426aa3d6e75)


### Webpay transaction in production
![image](https://github.com/user-attachments/assets/69435ee9-daeb-4807-bce5-14b370405155)

### Webapy transaction in integration
![image](https://github.com/user-attachments/assets/3795bf5a-5028-4cdd-8205-b9d48ab63168)

### Oneclick transaction in integration
![image](https://github.com/user-attachments/assets/3c3b72ac-bbc3-4152-8c5d-8092c5ab3863)




