### PR TITLE
feat: transbank sdk update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A continuación, encontrarás información necesaria para el desarrollo de este 
 # Requisitos
 
 -   PHP 8.2+ o superior
--   PrestaShop 1.7.8.0 o superior
+-   PrestaShop 8.0 o superior
 
 # Dependencias
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A continuación, encontrarás información necesaria para el desarrollo de este 
 
 # Requisitos
 
--   PHP 7.0+ o superior
+-   PHP 8.2+ o superior
 -   PrestaShop 1.7.8.0 o superior
 
 # Dependencias

--- a/webpay/composer.json
+++ b/webpay/composer.json
@@ -1,14 +1,14 @@
 {
     "require": {
-        "transbank/transbank-sdk": "~2.0",
-        "monolog/monolog": "^1.27",
-        "guzzlehttp/guzzle": "^5",
+        "transbank/transbank-sdk": "~5.0",
+        "monolog/monolog": "^2.0",
+        "guzzlehttp/guzzle": "^7",
         "ext-json": "*",
-        "php": ">=7.0"
+        "php": ">=8.2"
     },
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "8.2"
         }
     },
     "autoload": {

--- a/webpay/composer.json
+++ b/webpay/composer.json
@@ -2,7 +2,6 @@
     "require": {
         "transbank/transbank-sdk": "~5.0",
         "monolog/monolog": "^2.0",
-        "guzzlehttp/guzzle": "^7",
         "ext-json": "*",
         "php": ">=8.2"
     },

--- a/webpay/config_es.xml
+++ b/webpay/config_es.xml
@@ -3,10 +3,11 @@
     <name>webpay</name>
     <displayName><![CDATA[Webpay Plus]]></displayName>
     <version><![CDATA[1.0.0]]></version>
-    <description><![CDATA[Recibe pagos en l&iacute;nea con tarjetas de cr&eacute;dito y Redcompra en tu Prestashop a trav&eacute;s de Webpay Plus y Oneclick]]></description>
+    <description><![CDATA[Recibe pagos en l&iacute;nea con tarjetas de cr&eacute;dito y Redcompra en tu Prestashop a trav&eacute;s de Webpay Plus y Webpay Oneclick]]></description>
     <author><![CDATA[Transbank]]></author>
     <tab><![CDATA[payments_gateways]]></tab>
 	<confirmUninstall><![CDATA[¿Estás seguro/a que deseas desinstalar este módulo de pago?]]></confirmUninstall>
     <is_configurable>1</is_configurable>
     <need_instance>1</need_instance>
+    <limited_countries></limited_countries>
 </module>

--- a/webpay/config_es.xml
+++ b/webpay/config_es.xml
@@ -3,11 +3,10 @@
     <name>webpay</name>
     <displayName><![CDATA[Webpay Plus]]></displayName>
     <version><![CDATA[1.0.0]]></version>
-    <description><![CDATA[Recibe pagos en l&iacute;nea con tarjetas de cr&eacute;dito y Redcompra en tu Prestashop a trav&eacute;s de Webpay Plus]]></description>
+    <description><![CDATA[Recibe pagos en l&iacute;nea con tarjetas de cr&eacute;dito y Redcompra en tu Prestashop a trav&eacute;s de Webpay Plus y Oneclick]]></description>
     <author><![CDATA[Transbank]]></author>
     <tab><![CDATA[payments_gateways]]></tab>
 	<confirmUninstall><![CDATA[¿Estás seguro/a que deseas desinstalar este módulo de pago?]]></confirmUninstall>
     <is_configurable>1</is_configurable>
     <need_instance>1</need_instance>
-	<limited_countries></limited_countries>
 </module>

--- a/webpay/src/Config/OneclickConfig.php
+++ b/webpay/src/Config/OneclickConfig.php
@@ -93,10 +93,10 @@ class OneclickConfig extends AbstractModuleConfig
     public static function loadDefaultConfig(): void
     {
         self::setPaymentActive(TbkConstants::ACTIVE_MODULE);
-        self::setEnvironment(Options::DEFAULT_INTEGRATION_TYPE);
-        self::setCommerceCode(Oneclick::DEFAULT_COMMERCE_CODE);
-        self::setChildCommerceCode(Oneclick::DEFAULT_CHILD_COMMERCE_CODE_1);
-        self::setApiKey(Oneclick::DEFAULT_API_KEY);
+        self::setEnvironment(Options::ENVIRONMENT_INTEGRATION);
+        self::setCommerceCode(Oneclick::INTEGRATION_COMMERCE_CODE);
+        self::setChildCommerceCode(Oneclick::INTEGRATION_CHILD_COMMERCE_CODE_1);
+        self::setApiKey(Oneclick::INTEGRATION_API_KEY);
         self::setOrderStateIdAfterPayment(Configuration::get('PS_OS_PREPARATION'));
     }
 

--- a/webpay/src/Config/WebpayConfig.php
+++ b/webpay/src/Config/WebpayConfig.php
@@ -74,9 +74,9 @@ class WebpayConfig extends AbstractModuleConfig
     public static function loadDefaultConfig(): void
     {
         self::setPaymentActive(TbkConstants::ACTIVE_MODULE);
-        self::setEnvironment(Options::DEFAULT_INTEGRATION_TYPE);
-        self::setCommerceCode(WebpayPlus::DEFAULT_COMMERCE_CODE);
-        self::setApiKey(WebpayPlus::DEFAULT_API_KEY);
+        self::setEnvironment(Options::ENVIRONMENT_INTEGRATION);
+        self::setCommerceCode(WebpayPlus::INTEGRATION_COMMERCE_CODE);
+        self::setApiKey(WebpayPlus::INTEGRATION_API_KEY);
         self::setOrderStateIdAfterPayment(Configuration::get('PS_OS_PREPARATION'));
     }
 

--- a/webpay/src/Form/OneclickType.php
+++ b/webpay/src/Form/OneclickType.php
@@ -50,7 +50,7 @@ class OneclickType extends TranslatorAwareType
             ->add('form_oneclick_environment', SwitchType::class, [
                 'label' => $this->trans('Producción', 'Modules.WebpayPlus.Admin'),
                 'choices' => [
-                    $this->trans('No', 'Modules.WebpayPlus.Admin') => Options::DEFAULT_INTEGRATION_TYPE,
+                    $this->trans('No', 'Modules.WebpayPlus.Admin') => Options::ENVIRONMENT_INTEGRATION,
                     $this->trans('Si', 'Modules.WebpayPlus.Admin') => Options::ENVIRONMENT_PRODUCTION,
                 ],
                 'help' => $this->trans('Cuando no está activado el modo producción, se utilizarán las claves predeterminadas del entorno de pruebas.', 'Modules.WebpayPlus.Admin'),

--- a/webpay/src/Form/WebpayPlusType.php
+++ b/webpay/src/Form/WebpayPlusType.php
@@ -50,7 +50,7 @@ class WebpayPlusType extends TranslatorAwareType
             ->add('form_webpay_environment', SwitchType::class, [
                 'label' => $this->trans('Producción', 'Modules.WebpayPlus.Admin'),
                 'choices' => [
-                    $this->trans('No', 'Modules.WebpayPlus.Admin') => Options::DEFAULT_INTEGRATION_TYPE,
+                    $this->trans('No', 'Modules.WebpayPlus.Admin') => Options::ENVIRONMENT_INTEGRATION,
                     $this->trans('Si', 'Modules.WebpayPlus.Admin') => Options::ENVIRONMENT_PRODUCTION,
                 ],
                 'help' => $this->trans('Cuando no está activado el modo producción, se utilizarán las claves predeterminadas del entorno de pruebas.', 'Modules.WebpayPlus.Admin'),

--- a/webpay/src/Utils/TransbankSdkOneclick.php
+++ b/webpay/src/Utils/TransbankSdkOneclick.php
@@ -35,11 +35,20 @@ class TransbankSdkOneclick
     public function __construct($config)
     {
         $this->log = TbkFactory::createLogger();
-        $this->options = new Options(
-            $config['API_KEY_SECRET'],
-            $config['COMMERCE_CODE'],
-            $config['ENVIRONMENT']
-        );
+
+        if($config['ENVIRONMENT'] == Options::ENVIRONMENT_PRODUCTION) {
+            $this->options = new Options(
+                $config['API_KEY_SECRET'],
+                $config['COMMERCE_CODE'],
+                $config['ENVIRONMENT']
+            );
+        } else {
+            $this->options = new Options(
+                Oneclick::INTEGRATION_API_KEY,
+                Oneclick::INTEGRATION_COMMERCE_CODE,
+                $config['ENVIRONMENT']
+            );
+        }
 
         $this->inscription = new MallInscription($this->options);
         $this->transaction = new MallTransaction($this->options);

--- a/webpay/src/Utils/TransbankSdkOneclick.php
+++ b/webpay/src/Utils/TransbankSdkOneclick.php
@@ -35,21 +35,17 @@ class TransbankSdkOneclick
     public function __construct($config)
     {
         $this->log = TbkFactory::createLogger();
-        $this->options = new Options(
-            Oneclick::INTEGRATION_API_KEY,
-            Oneclick::INTEGRATION_COMMERCE_CODE,
-            Options::ENVIRONMENT_INTEGRATION
-        );
-        $environment = isset($config['ENVIRONMENT']) ? $config['ENVIRONMENT'] : null;
-        if (isset($config) && $environment == Options::ENVIRONMENT_PRODUCTION){
-            $this->options = new Options(
-                $config['API_KEY_SECRET'],
-                $config['COMMERCE_CODE'],
-                Options::ENVIRONMENT_PRODUCTION
-            );
-        }
-        $this->inscription = new MallInscription($this->options);
-        $this->transaction = new MallTransaction($this->options);
+        $environment = $config['ENVIRONMENT'] ?? null;
+
+        $this->inscription = ($environment == Options::ENVIRONMENT_PRODUCTION)
+            ? MallInscription::buildForProduction($config['API_KEY_SECRET'], $config['COMMERCE_CODE'])
+            : MallInscription::buildForIntegration(Oneclick::INTEGRATION_API_KEY, Oneclick::INTEGRATION_COMMERCE_CODE);
+        
+        $this->transaction = ($environment == Options::ENVIRONMENT_PRODUCTION)
+            ? MallTransaction::buildForProduction($config['API_KEY_SECRET'], $config['COMMERCE_CODE'])
+            : MallTransaction::buildForIntegration(Oneclick::INTEGRATION_API_KEY, Oneclick::INTEGRATION_COMMERCE_CODE);
+
+        $this->options = $this->inscription->getOptions();
         $this->childCommerceCode = $config['CHILD_COMMERCE_CODE'];
     }
 

--- a/webpay/src/Utils/TransbankSdkOneclick.php
+++ b/webpay/src/Utils/TransbankSdkOneclick.php
@@ -42,7 +42,6 @@ class TransbankSdkOneclick
         );
         $environment = isset($config['ENVIRONMENT']) ? $config['ENVIRONMENT'] : null;
         if (isset($config) && $environment == Options::ENVIRONMENT_PRODUCTION){
-            $this->options = Options::forProduction($config['COMMERCE_CODE'], $config['API_KEY_SECRET']);
             $this->options = new Options(
                 $config['API_KEY_SECRET'],
                 $config['COMMERCE_CODE'],

--- a/webpay/src/Utils/TransbankSdkOneclick.php
+++ b/webpay/src/Utils/TransbankSdkOneclick.php
@@ -4,6 +4,7 @@ namespace PrestaShop\Module\WebpayPlus\Utils;
 
 use PrestaShop\Module\WebpayPlus\Helpers\TbkFactory;
 use Transbank\Plugin\Exceptions\EcommerceException;
+use Transbank\Webpay\Oneclick;
 use Transbank\Webpay\Options;
 use Transbank\Webpay\Oneclick\MallInscription;
 use Transbank\Webpay\Oneclick\MallTransaction;
@@ -34,10 +35,19 @@ class TransbankSdkOneclick
     public function __construct($config)
     {
         $this->log = TbkFactory::createLogger();
-        $this->options = MallInscription::getDefaultOptions();
+        $this->options = new Options(
+            Oneclick::INTEGRATION_API_KEY,
+            Oneclick::INTEGRATION_COMMERCE_CODE,
+            Options::ENVIRONMENT_INTEGRATION
+        );
         $environment = isset($config['ENVIRONMENT']) ? $config['ENVIRONMENT'] : null;
         if (isset($config) && $environment == Options::ENVIRONMENT_PRODUCTION){
             $this->options = Options::forProduction($config['COMMERCE_CODE'], $config['API_KEY_SECRET']);
+            $this->options = new Options(
+                $config['API_KEY_SECRET'],
+                $config['COMMERCE_CODE'],
+                Options::ENVIRONMENT_PRODUCTION
+            );
         }
         $this->inscription = new MallInscription($this->options);
         $this->transaction = new MallTransaction($this->options);

--- a/webpay/src/Utils/TransbankSdkOneclick.php
+++ b/webpay/src/Utils/TransbankSdkOneclick.php
@@ -35,17 +35,14 @@ class TransbankSdkOneclick
     public function __construct($config)
     {
         $this->log = TbkFactory::createLogger();
-        $environment = $config['ENVIRONMENT'] ?? null;
+        $this->options = new Options(
+            $config['API_KEY_SECRET'],
+            $config['COMMERCE_CODE'],
+            $config['ENVIRONMENT']
+        );
 
-        $this->inscription = ($environment == Options::ENVIRONMENT_PRODUCTION)
-            ? MallInscription::buildForProduction($config['API_KEY_SECRET'], $config['COMMERCE_CODE'])
-            : MallInscription::buildForIntegration(Oneclick::INTEGRATION_API_KEY, Oneclick::INTEGRATION_COMMERCE_CODE);
-        
-        $this->transaction = ($environment == Options::ENVIRONMENT_PRODUCTION)
-            ? MallTransaction::buildForProduction($config['API_KEY_SECRET'], $config['COMMERCE_CODE'])
-            : MallTransaction::buildForIntegration(Oneclick::INTEGRATION_API_KEY, Oneclick::INTEGRATION_COMMERCE_CODE);
-
-        $this->options = $this->inscription->getOptions();
+        $this->inscription = new MallInscription($this->options);
+        $this->transaction = new MallTransaction($this->options);
         $this->childCommerceCode = $config['CHILD_COMMERCE_CODE'];
     }
 

--- a/webpay/src/Utils/TransbankSdkWebpay.php
+++ b/webpay/src/Utils/TransbankSdkWebpay.php
@@ -33,13 +33,13 @@ class TransbankSdkWebpay
     public function __construct($config)
     {
         $this->log = TbkFactory::createLogger();
-        $environment = $config['ENVIRONMENT'] ?? null;
+        $this->options = new Options(
+            $config['API_KEY_SECRET'],
+            $config['COMMERCE_CODE'],
+            $config['ENVIRONMENT']
+        );
 
-        $this->transaction = ($environment == Options::ENVIRONMENT_PRODUCTION)
-            ? Transaction::buildForProduction($config['API_KEY_SECRET'], $config['COMMERCE_CODE'])
-            : Transaction::buildForIntegration(WebpayPlus::INTEGRATION_API_KEY, WebpayPlus::INTEGRATION_COMMERCE_CODE);
-        
-        $this->options = $this->transaction->getOptions();
+        $this->transaction = new Transaction($this->options);
     }
 
     public function getCommerceCode()

--- a/webpay/src/Utils/TransbankSdkWebpay.php
+++ b/webpay/src/Utils/TransbankSdkWebpay.php
@@ -33,19 +33,13 @@ class TransbankSdkWebpay
     public function __construct($config)
     {
         $this->log = TbkFactory::createLogger();
-        $this->options = new Options(
-            WebpayPlus::INTEGRATION_API_KEY,
-            WebpayPlus::INTEGRATION_COMMERCE_CODE,
-            Options::ENVIRONMENT_INTEGRATION
-        );
-        $environment = isset($config['ENVIRONMENT']) ? $config['ENVIRONMENT'] : null;
-        if (isset($config) && $environment == Options::ENVIRONMENT_PRODUCTION) {
-            $this->options = new Options(
-                $config['API_KEY_SECRET'],
-                $config['COMMERCE_CODE'],
-                Options::ENVIRONMENT_PRODUCTION);
-        }
-        $this->transaction = new Transaction($this->options);
+        $environment = $config['ENVIRONMENT'] ?? null;
+
+        $this->transaction = ($environment == Options::ENVIRONMENT_PRODUCTION)
+            ? Transaction::buildForProduction($config['API_KEY_SECRET'], $config['COMMERCE_CODE'])
+            : Transaction::buildForIntegration(WebpayPlus::INTEGRATION_API_KEY, WebpayPlus::INTEGRATION_COMMERCE_CODE);
+        
+        $this->options = $this->transaction->getOptions();
     }
 
     public function getCommerceCode()

--- a/webpay/src/Utils/TransbankSdkWebpay.php
+++ b/webpay/src/Utils/TransbankSdkWebpay.php
@@ -11,6 +11,7 @@ use Transbank\Webpay\WebpayPlus\Responses\TransactionCommitResponse;
 use Transbank\Webpay\WebpayPlus\Transaction;
 use Transbank\Webpay\WebpayPlus\Exceptions\TransactionCommitException;
 use Transbank\Webpay\WebpayPlus\Exceptions\TransactionCreateException;
+use WebPay;
 
 /**
  * Class TransbankSdkWebpayRest.
@@ -33,11 +34,20 @@ class TransbankSdkWebpay
     public function __construct($config)
     {
         $this->log = TbkFactory::createLogger();
-        $this->options = new Options(
-            $config['API_KEY_SECRET'],
-            $config['COMMERCE_CODE'],
-            $config['ENVIRONMENT']
-        );
+
+        if($config['ENVIRONMENT'] == Options::ENVIRONMENT_PRODUCTION) {
+            $this->options = new Options(
+                $config['API_KEY_SECRET'],
+                $config['COMMERCE_CODE'],
+                $config['ENVIRONMENT']
+            );
+        } else {
+            $this->options = new Options(
+                WebpayPlus::INTEGRATION_API_KEY,
+                WebpayPlus::INTEGRATION_COMMERCE_CODE,
+                $config['ENVIRONMENT']
+            );
+        }
 
         $this->transaction = new Transaction($this->options);
     }

--- a/webpay/src/Utils/TransbankSdkWebpay.php
+++ b/webpay/src/Utils/TransbankSdkWebpay.php
@@ -33,9 +33,9 @@ class TransbankSdkWebpay
     public function __construct($config)
     {
         $this->log = TbkFactory::createLogger();
-        $this->options = new Options(   
-            WebpayPlus::INTEGRATION_API_KEY,    
-            WebpayPlus::INTEGRATION_COMMERCE_CODE,  
+        $this->options = new Options(
+            WebpayPlus::INTEGRATION_API_KEY,
+            WebpayPlus::INTEGRATION_COMMERCE_CODE,
             Options::ENVIRONMENT_INTEGRATION
         );
         $environment = isset($config['ENVIRONMENT']) ? $config['ENVIRONMENT'] : null;

--- a/webpay/src/Utils/TransbankSdkWebpay.php
+++ b/webpay/src/Utils/TransbankSdkWebpay.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use PrestaShop\Module\WebpayPlus\Helpers\TbkFactory;
 use Transbank\Plugin\Exceptions\EcommerceException;
 use Transbank\Webpay\Options;
+use Transbank\Webpay\WebpayPlus;
 use Transbank\Webpay\WebpayPlus\Responses\TransactionCommitResponse;
 use Transbank\Webpay\WebpayPlus\Transaction;
 use Transbank\Webpay\WebpayPlus\Exceptions\TransactionCommitException;
@@ -32,10 +33,17 @@ class TransbankSdkWebpay
     public function __construct($config)
     {
         $this->log = TbkFactory::createLogger();
-        $this->options = Transaction::getDefaultOptions();
+        $this->options = new Options(   
+            WebpayPlus::INTEGRATION_API_KEY,    
+            WebpayPlus::INTEGRATION_COMMERCE_CODE,  
+            Options::ENVIRONMENT_INTEGRATION
+        );
         $environment = isset($config['ENVIRONMENT']) ? $config['ENVIRONMENT'] : null;
         if (isset($config) && $environment == Options::ENVIRONMENT_PRODUCTION) {
-            $this->options = Options::forProduction($config['COMMERCE_CODE'], $config['API_KEY_SECRET']);
+            $this->options = new Options(
+                $config['API_KEY_SECRET'],
+                $config['COMMERCE_CODE'],
+                Options::ENVIRONMENT_PRODUCTION);
         }
         $this->transaction = new Transaction($this->options);
     }


### PR DESCRIPTION
This pr updates the transbank sdk version to ~5.0 (any version >=5.0.0 and <6.0.0), also updating related libraries, readme, required configs and constructors to work properly.

## Tests
In this case, the tests has been run by @mastudillot in their local machine since the prestashop docker image to set up the development environment uses php 8.1, and the minimum php version for transbank sdk is php 8.2. You can check the slack thread were the tests and fixes were made until the plugin was working [here](https://continuumhq.slack.com/archives/C07GV91KT2Q/p1750265568571989)