### PR TITLE
feat: add view to remove oneclick cards

### DIFF
--- a/webpay/controllers/front/oneclickcards.php
+++ b/webpay/controllers/front/oneclickcards.php
@@ -45,6 +45,10 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
     public function postProcess(): void
     {
         try {
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                return;
+            }
+
             $this->validatePostRequest();
 
             $idCard = (int) Tools::getValue('id_card');

--- a/webpay/controllers/front/oneclickcards.php
+++ b/webpay/controllers/front/oneclickcards.php
@@ -189,9 +189,10 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
     {
         $cardTypePrefix = $this->environment === Options::ENVIRONMENT_INTEGRATION ? '[TEST]' : '';
         return array_values(array_map(function ($card) use ($cardTypePrefix) {
+            $lastDigitsLength = 4;
             $cardNumber = $card['card_number'] ?? null;
-            if ($cardNumber && strlen($cardNumber) > 4) {
-                $cardNumber = substr($cardNumber, -4);
+            if ($cardNumber && strlen($cardNumber) > $lastDigitsLength) {
+                $cardNumber = substr($cardNumber, -$lastDigitsLength);
             }
             return [
                 'id_card' => $card['id'] ?? null,

--- a/webpay/controllers/front/oneclickcards.php
+++ b/webpay/controllers/front/oneclickcards.php
@@ -87,8 +87,6 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
             'strings' => [
                 'title' => $this->trans('Tarjetas Oneclick Inscritas', [], 'Modules.WebPay.Shop'),
                 'delete' => $this->trans('Eliminar', [], 'Modules.WebPay.Shop'),
-                'make_default' => $this->trans('Hacer predeterminada', [], 'Modules.WebPay.Shop'),
-                'default' => $this->trans('Predeterminada', [], 'Modules.WebPay.Shop'),
                 'no_cards' => $this->trans('Aún no tienes tarjetas inscritas.', [], 'Modules.WebPay.Shop'),
                 'back' => $this->trans('Volver a mi cuenta', [], 'Modules.WebPay.Shop'),
             ],

--- a/webpay/controllers/front/oneclickcards.php
+++ b/webpay/controllers/front/oneclickcards.php
@@ -148,11 +148,7 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
             throw new EcommerceException('Inscripción no encontrada.');
         }
 
-        $result = $this->oneclickService->delete($inscription['tbk_token'], $inscription['username']);
-
-        if (!$result) {
-            throw new EcommerceException('Error al eliminar la tarjeta en Transbank.');
-        }
+        $this->oneclickService->delete($inscription['tbk_token'], $inscription['username']);
 
         $deleted = $this->repository->deleteInscriptionByUserAndId($customerId, $cardId);
         if (!$deleted) {

--- a/webpay/controllers/front/oneclickcards.php
+++ b/webpay/controllers/front/oneclickcards.php
@@ -1,0 +1,219 @@
+<?php
+
+use Transbank\Webpay\Options;
+use Transbank\Plugin\Exceptions\EcommerceException;
+use PrestaShop\Module\WebpayPlus\Helpers\TbkFactory;
+use PrestaShop\Module\WebpayPlus\Helpers\OneclickFactory;
+use PrestaShop\Module\WebpayPlus\Repository\InscriptionRepository;
+
+class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
+{
+    public $auth = true;
+    public $ssl = true;
+
+    /** @var InscriptionRepository */
+    private $repository;
+
+    /** @var Transbank\Plugin\Helpers\PluginLogger */
+    private $log;
+
+    /** @var PrestaShop\Module\WebpayPlus\Utils\TransbankSdkOneclick */
+    private $oneclickService;
+
+    /** @var string */
+    private $environment;
+
+    /**
+     * Initializes the controller with required dependencies for handling Oneclick card operations.
+     * Sets up repository, logger, service, and environment configuration.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->repository = new InscriptionRepository();
+        $this->log = TbkFactory::createLogger();
+        $this->oneclickService = OneclickFactory::create();
+        $this->environment = $this->oneclickService->getEnvironment();
+    }
+
+    /**
+     * Processes POST requests for card deletion operations.
+     * Validates the request, authenticates the user, and handles card deletion workflow.
+     * 
+     * @return void
+     */
+    public function postProcess(): void
+    {
+        try {
+            $this->validatePostRequest();
+
+            $idCard = (int) Tools::getValue('id_card');
+            $idCustomer = (int) $this->context->customer->id;
+
+            $this->handleDeleteCard((string) $idCard, (string) $idCustomer);
+        } catch (Exception $e) {
+            $this->errors[] = "No se pudo eliminar la tarjeta, por favor intente nuevamente. En caso de persistir el error, contacte al comercio.";
+            $this->log->logError($e->getMessage());
+            return;
+        }
+    }
+
+    /**
+     * Initializes the content for the Oneclick cards management page.
+     * Retrieves user cards, generates CSRF token, and assigns template variables.
+     * 
+     * @return void
+     */
+    public function initContent()
+    {
+        parent::initContent();
+
+        $idCustomer = (int) $this->context->customer->id;
+        $cards = $this->repository->getCardsByUserId($idCustomer);
+        $cards = $this->formatCardData($cards);
+
+        $this->context->smarty->assign([
+            'cards' => $cards,
+            'csrf_token' => Tools::getToken(true),
+            'list_url' => $this->context->link->getModuleLink($this->module->name, 'oneclickcards'),
+            'back_to_account_url' => $this->context->link->getPageLink('my-account', true),
+            'oneclick_image_url' => $this->context->link->getMediaLink(
+                $this->module->getPathUri() . '/views/img/oneclick.png'
+            ),
+            'strings' => [
+                'title' => $this->trans('Tarjetas Oneclick Inscritas', [], 'Modules.WebPay.Shop'),
+                'delete' => $this->trans('Eliminar', [], 'Modules.WebPay.Shop'),
+                'make_default' => $this->trans('Hacer predeterminada', [], 'Modules.WebPay.Shop'),
+                'default' => $this->trans('Predeterminada', [], 'Modules.WebPay.Shop'),
+                'no_cards' => $this->trans('Aún no tienes tarjetas inscritas.', [], 'Modules.WebPay.Shop'),
+                'back' => $this->trans('Volver a mi cuenta', [], 'Modules.WebPay.Shop'),
+            ],
+        ]);
+
+        $this->setTemplate("module:{$this->module->name}/views/templates/front/oneclick_cards.tpl");
+    }
+
+    /**
+     * Generates breadcrumb navigation links for the page.
+     * Adds navigation path from home -> account -> oneclick cards.
+     * 
+     * @return array Breadcrumb structure with navigation links
+     */
+    public function getBreadcrumbLinks(): array
+    {
+        $breadcrumb = parent::getBreadcrumbLinks();
+
+        $breadcrumb['links'][] = [
+            'title' => $this->trans('Su cuenta', [], 'Shop.Theme.Customeraccount'),
+            'url' => $this->context->link->getPageLink('my-account', true),
+        ];
+
+        $breadcrumb['links'][] = [
+            'title' => $this->trans('Tarjetas Oneclick Inscritas', [], 'Modules.Webpay.Shop'),
+            'url' => $this->context->link->getModuleLink('webpay', 'oneclickcards'),
+        ];
+
+        return $breadcrumb;
+    }
+
+    /**
+     * Customizes page template variables, particularly the meta title.
+     * 
+     * @return array Page template variables including meta information
+     */
+    public function getTemplateVarPage(): array
+    {
+        $page = parent::getTemplateVarPage();
+        $page['meta']['title'] = $this->trans('Tarjetas guardadas', [], 'Modules.Webpay.Shop');
+        return $page;
+    }
+
+    /**
+     * Handles the complete card deletion workflow.
+     * Validates card existence, deletes from Transbank, and removes from local database.
+     * 
+     * @param string $cardId The unique identifier of the card to delete
+     * @param string $customerId The customer's unique identifier
+     * @return void
+     * @throws EcommerceException When card is not found, Transbank deletion fails, or database deletion fails
+     */
+    private function handleDeleteCard(string $cardId, string $customerId): void
+    {
+        $this->log->logInfo("Iniciando eliminación de tarjeta => cardId: {$cardId}, customerId: {$customerId}");
+        $inscription = $this->repository->getOneByUserIdAndInscriptionId($customerId, $cardId);
+
+        if (!$inscription) {
+            throw new EcommerceException('Inscripción no encontrada.');
+        }
+
+        $result = $this->oneclickService->delete($inscription['tbk_token'], $inscription['username']);
+
+        if (!$result) {
+            throw new EcommerceException('Error al eliminar la tarjeta en Transbank.');
+        }
+
+        $deleted = $this->repository->deleteInscriptionByUserAndId($customerId, $cardId);
+        if (!$deleted) {
+            throw new EcommerceException('No se pudo eliminar la inscripción de la base de datos.');
+        }
+
+        $this->success[] = $this->trans('Tarjeta eliminada.', [], 'Modules.WebPay.Shop');
+        $this->log->logInfo("Tarjeta eliminada correctamente => cardId: {$cardId}, customerId: {$customerId}");
+    }
+
+    /**
+     * Validates incoming POST request for security and required parameters.
+     * Checks for required fields and CSRF token validity.
+     * 
+     * @return void
+     * @throws EcommerceException When request is invalid or CSRF token is missing/invalid
+     */
+    private function validatePostRequest(): void
+    {
+        if (!Tools::isSubmit('id_card')) {
+            throw new EcommerceException('Petición inválida.');
+        }
+
+        $token = Tools::getValue('csrf_token');
+        if (!$this->isValidCsrf($token)) {
+            throw new EcommerceException('Token CSRF inválido.');
+        }
+    }
+
+    /**
+     * Formats raw card data for template display.
+     * Masks card numbers, adds environment prefixes, and filters by current environment.
+     * 
+     * @param array $cards Raw card data from database
+     * @return array Formatted card data ready for template display with masked numbers and environment filtering
+     */
+    private function formatCardData(array $cards): array
+    {
+        $cardTypePrefix = $this->environment === Options::ENVIRONMENT_INTEGRATION ? '[TEST]' : '';
+        return array_values(array_map(function ($card) use ($cardTypePrefix) {
+            $cardNumber = $card['card_number'] ?? null;
+            if ($cardNumber && strlen($cardNumber) > 4) {
+                $cardNumber = substr($cardNumber, -4);
+            }
+            return [
+                'id_card' => $card['id'] ?? null,
+                'card_type' => "{$cardTypePrefix}{$card['card_type']}" ?? null,
+                'card_number' => $cardNumber,
+                'created_at' => $card['created_at'] ?? null,
+            ];
+        }, array_filter($cards, function ($card) {
+            return $card['environment'] === $this->environment;
+        })));
+    }
+
+    /**
+     * Validates CSRF token against PrestaShop's built-in token system.
+     * 
+     * @param mixed $token The CSRF token to validate (expected to be string)
+     * @return bool True if token is valid and matches expected value, false otherwise
+     */
+    private function isValidCsrf($token)
+    {
+        return is_string($token) && hash_equals(Tools::getToken(true), $token);
+    }
+}

--- a/webpay/controllers/front/oneclickcards.php
+++ b/webpay/controllers/front/oneclickcards.php
@@ -39,7 +39,7 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
     /**
      * Processes POST requests for card deletion operations.
      * Validates the request, authenticates the user, and handles card deletion workflow.
-     * 
+     *
      * @return void
      */
     public function postProcess(): void
@@ -65,7 +65,7 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
     /**
      * Initializes the content for the Oneclick cards management page.
      * Retrieves user cards, generates CSRF token, and assigns template variables.
-     * 
+     *
      * @return void
      */
     public function initContent()
@@ -100,7 +100,7 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
     /**
      * Generates breadcrumb navigation links for the page.
      * Adds navigation path from home -> account -> oneclick cards.
-     * 
+     *
      * @return array Breadcrumb structure with navigation links
      */
     public function getBreadcrumbLinks(): array
@@ -122,7 +122,7 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
 
     /**
      * Customizes page template variables, particularly the meta title.
-     * 
+     *
      * @return array Page template variables including meta information
      */
     public function getTemplateVarPage(): array
@@ -135,7 +135,7 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
     /**
      * Handles the complete card deletion workflow.
      * Validates card existence, deletes from Transbank, and removes from local database.
-     * 
+     *
      * @param string $cardId The unique identifier of the card to delete
      * @param string $customerId The customer's unique identifier
      * @return void
@@ -168,7 +168,7 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
     /**
      * Validates incoming POST request for security and required parameters.
      * Checks for required fields and CSRF token validity.
-     * 
+     *
      * @return void
      * @throws EcommerceException When request is invalid or CSRF token is missing/invalid
      */
@@ -187,7 +187,7 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
     /**
      * Formats raw card data for template display.
      * Masks card numbers, adds environment prefixes, and filters by current environment.
-     * 
+     *
      * @param array $cards Raw card data from database
      * @return array Formatted card data ready for template display with masked numbers and environment filtering
      */
@@ -212,7 +212,7 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
 
     /**
      * Validates CSRF token against PrestaShop's built-in token system.
-     * 
+     *
      * @param mixed $token The CSRF token to validate (expected to be string)
      * @return bool True if token is valid and matches expected value, false otherwise
      */

--- a/webpay/controllers/front/oneclickcards.php
+++ b/webpay/controllers/front/oneclickcards.php
@@ -51,10 +51,10 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
 
             $this->validatePostRequest();
 
-            $idCard = (int) Tools::getValue('id_card');
-            $idCustomer = (int) $this->context->customer->id;
+            $idCard = Tools::getValue('id_card');
+            $idCustomer = $this->context->customer->id;
 
-            $this->handleDeleteCard((string) $idCard, (string) $idCustomer);
+            $this->handleDeleteCard($idCard, $idCustomer);
         } catch (Exception $e) {
             $this->errors[] = "No se pudo eliminar la tarjeta, por favor intente nuevamente. En caso de persistir el error, contacte al comercio.";
             $this->log->logError($e->getMessage());

--- a/webpay/controllers/front/oneclickinscription.php
+++ b/webpay/controllers/front/oneclickinscription.php
@@ -35,7 +35,7 @@ class WebPayOneclickInscriptionModuleFrontController extends BaseModuleFrontCont
         $ins->pay_after_inscription = false;
         $ins->from = 'checkout';
         $ins->status = TransbankInscriptions::STATUS_INITIALIZED;
-        $ins->environment = $webpay->getEnviroment();
+        $ins->environment = $webpay->getEnvironment();
         $ins->commerce_code = $webpay->getCommerceCode();
         $ins->order_id = $this->module->currentOrder;//importante para recuperar la orden en curso y el carro en curso
         $saved = $ins->save();

--- a/webpay/controllers/front/oneclickpaymentvalidate.php
+++ b/webpay/controllers/front/oneclickpaymentvalidate.php
@@ -97,7 +97,7 @@ class WebPayOneclickPaymentValidateModuleFrontController extends PaymentModuleFr
         //$transaction->shop_id = (int) Context::getContext()->shop->id;
         $transaction->currency_id = (int) $cart->id_currency;
 
-        $transaction->environment = $webpay->getEnviroment();
+        $transaction->environment = $webpay->getEnvironment();
         $transaction->product = TransbankWebpayRestTransaction::PRODUCT_WEBPAY_ONECLICK;
         $transaction->commerce_code = $webpay->getCommerceCode();
         $transaction->child_commerce_code = $webpay->getChildCommerceCode();

--- a/webpay/controllers/front/webpaypluspayment.php
+++ b/webpay/controllers/front/webpaypluspayment.php
@@ -108,7 +108,7 @@ class WebPayWebpayplusPaymentModuleFrontController extends BaseModuleFrontContro
         $transaction->currency_id = $currencyId;
 
         $transaction->commerce_code = $webpay->getCommerceCode();
-        $transaction->environment = $webpay->getEnviroment();
+        $transaction->environment = $webpay->getEnvironment();
         $transaction->product = TransbankWebpayRestTransaction::PRODUCT_WEBPAY_PLUS;
 
         $this->logInfo("Creando registro en la tabla webpay_transactions [Datos]:");

--- a/webpay/src/Hooks/DisplayCustomerAccount.php
+++ b/webpay/src/Hooks/DisplayCustomerAccount.php
@@ -5,7 +5,7 @@ namespace PrestaShop\Module\WebpayPlus\Hooks;
 use Module;
 use Context;
 use Transbank\Plugin\Helpers\TbkConstants;
-use PrestaShop\Module\WebpayPlus\Utils\Template;
+use PrestaShop\Module\WebpayPlus\Config\OneclickConfig;
 use PrestaShop\Module\WebpayPlus\Hooks\AbstractHookHandler;
 
 /**
@@ -35,6 +35,10 @@ class DisplayCustomerAccount extends AbstractHookHandler
     public function execute(array $params): ?string
     {
         $this->logInfo('Ejecutando hook DisplayCustomerAccount');
+
+        if (!OneclickConfig::isPaymentMethodActive()) {
+            return '';
+        }
 
         $module = $params['module'] ?? Module::getInstanceByName('webpay');
         $context = $params['context'] ?? Context::getContext();

--- a/webpay/src/Hooks/DisplayCustomerAccount.php
+++ b/webpay/src/Hooks/DisplayCustomerAccount.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace PrestaShop\Module\WebpayPlus\Hooks;
+
+use Module;
+use Context;
+use Transbank\Plugin\Helpers\TbkConstants;
+use PrestaShop\Module\WebpayPlus\Utils\Template;
+use PrestaShop\Module\WebpayPlus\Hooks\AbstractHookHandler;
+
+/**
+ * Class DisplayCustomerAccount
+ *
+ * This class is responsible for displaying Webpay account information and transaction links
+ * in the customer account area. It renders a link to view the customer's transaction history
+ * and other account-related information for the Webpay module.
+ */
+class DisplayCustomerAccount extends AbstractHookHandler
+{
+    /**
+     * Constructor.
+     * Initializes the class.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Executes the hook logic to display customer account information.
+     *
+     * @param array $params The parameters passed to the hook.
+     * @return string|null Rendered template as a string, or null if there's an error.
+     */
+    public function execute(array $params): ?string
+    {
+        $this->logInfo('Ejecutando hook DisplayCustomerAccount');
+
+        $module = $params['module'] ?? Module::getInstanceByName('webpay');
+        $context = $params['context'] ?? Context::getContext();
+
+        $this->logInfo('Hook DisplayCustomerAccount ejecutado correctamente');
+
+        $context->smarty->assign([
+            'oneclickCardsLink' => $context->link->getModuleLink(
+                TbkConstants::MODULE_NAME,
+                'oneclickcards'
+            ),
+        ]);
+        return $context->smarty->fetch("module:{$module->name}/views/templates/hook/displayCustomerAccount.tpl");
+    }
+}

--- a/webpay/src/Hooks/DisplayCustomerAccount.php
+++ b/webpay/src/Hooks/DisplayCustomerAccount.php
@@ -18,15 +18,6 @@ use PrestaShop\Module\WebpayPlus\Hooks\AbstractHookHandler;
 class DisplayCustomerAccount extends AbstractHookHandler
 {
     /**
-     * Constructor.
-     * Initializes the class.
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Executes the hook logic to display customer account information.
      *
      * @param array $params The parameters passed to the hook.

--- a/webpay/src/Repository/InscriptionRepository.php
+++ b/webpay/src/Repository/InscriptionRepository.php
@@ -42,11 +42,28 @@ class InscriptionRepository
      *
      * @return array Inscriptions data.
      */
-    public function getCardsByUserId($userId): array
+    public function getCardsByUserId(string $userId): array
     {
         return $this->getInscriptionsByConditions([
             'user_id' => $userId,
             'status' => TransbankInscriptions::STATUS_COMPLETED,
         ]);
+    }
+
+    /**
+     * Get a single inscription by user ID and inscription ID.
+     *
+     * @param string $userId
+     * @param string $inscriptionId
+     */
+    public function getOneByUserIdAndInscriptionId(string $userId, string $inscriptionId): ?array
+    {
+        $results = $this->getInscriptionsByConditions([
+            'user_id' => $userId,
+            'id' => $inscriptionId,
+            'status' => TransbankInscriptions::STATUS_COMPLETED,
+        ]);
+
+        return !empty($results) ? $results[0] : null;
     }
 }

--- a/webpay/src/Repository/InscriptionRepository.php
+++ b/webpay/src/Repository/InscriptionRepository.php
@@ -66,4 +66,35 @@ class InscriptionRepository
 
         return !empty($results) ? $results[0] : null;
     }
+
+    /**
+     * Delete an inscription by user ID and inscription ID, only if status is completed.
+     * Delete its limited to one row.
+     *
+     * @param string $userId User ID.
+     * @param string $inscriptionId Inscription ID.
+     *
+     * @return bool True if a row was deleted, false otherwise.
+     */
+    public function deleteInscriptionByUserAndId(string $userId, string $inscriptionId): bool
+    {
+        $tableName = pSQL(_DB_PREFIX_ . TransbankInscriptions::TABLE_NAME);
+        $userId = (int) pSQL($userId);
+        $inscriptionId = (int) pSQL($inscriptionId);
+        $status = TransbankInscriptions::STATUS_COMPLETED;
+
+        if ($userId <= 0 || $inscriptionId <= 0) {
+            return false;
+        }
+
+        $sql = "DELETE FROM {$tableName}
+                WHERE `user_id` = {$userId}
+                  AND `id` = {$inscriptionId}
+                  AND `status` = '{$status}'
+                  LIMIT 1";
+
+        $result = Db::getInstance()->execute($sql);
+
+        return $result && Db::getInstance()->Affected_Rows() > 0;
+    }
 }

--- a/webpay/src/Utils/TransbankSdkOneclick.php
+++ b/webpay/src/Utils/TransbankSdkOneclick.php
@@ -59,7 +59,8 @@ class TransbankSdkOneclick
         return $this->options->getCommerceCode();
     }
 
-    public function getEnviroment(){
+    public function getEnvironment()
+    {
         return $this->options->getIntegrationType();
     }
 

--- a/webpay/src/Utils/TransbankSdkOneclick.php
+++ b/webpay/src/Utils/TransbankSdkOneclick.php
@@ -5,6 +5,7 @@ namespace PrestaShop\Module\WebpayPlus\Utils;
 use PrestaShop\Module\WebpayPlus\Helpers\TbkFactory;
 use Transbank\Plugin\Exceptions\EcommerceException;
 use Transbank\Webpay\Oneclick;
+use Transbank\Webpay\Oneclick\Exceptions\InscriptionDeleteException;
 use Transbank\Webpay\Options;
 use Transbank\Webpay\Oneclick\MallInscription;
 use Transbank\Webpay\Oneclick\MallTransaction;
@@ -133,6 +134,32 @@ class TransbankSdkOneclick
             throw new EcommerceException($errorMessage, $e);
         }
         return $result;
+    }
+
+    /**
+     * @param $userName
+     * @param $tbkUser
+     *
+     * @throws EcommerceException
+     *
+     * @return bool
+     */
+    public function delete(string $tbkUser, string $userName): bool
+    {
+        try {
+            $txDate = date('d-m-Y');
+            $txTime = date('H:i:s');
+            $this->log->logInfo('delete => userName: ' . $userName . ', tbkUser: ' . $tbkUser .
+                ', txDate: ' . $txDate . ', txTime: ' . $txTime);
+            $resp = $this->inscription->delete($tbkUser, $userName);
+            $this->log->logInfo('delete - resp: ' . json_encode($resp));
+            return $resp;
+        } catch (InscriptionDeleteException $e) {
+            $errorMessage = "Error al eliminar la inscripción para =>
+                userName: {$userName}, tbkUser: {$tbkUser}, error: {$e->getMessage()}";
+            $this->log->logError($errorMessage);
+            throw new EcommerceException($errorMessage, $e);
+        }
     }
 
     /**

--- a/webpay/src/Utils/TransbankSdkWebpay.php
+++ b/webpay/src/Utils/TransbankSdkWebpay.php
@@ -56,7 +56,7 @@ class TransbankSdkWebpay
         return $this->options->getCommerceCode();
     }
 
-    public function getEnviroment()
+    public function getEnvironment()
     {
         return $this->options->getIntegrationType();
     }

--- a/webpay/views/templates/front/oneclick_cards.tpl
+++ b/webpay/views/templates/front/oneclick_cards.tpl
@@ -1,0 +1,54 @@
+{extends file='page.tpl'}
+
+{block name='page_title'}
+  {$strings.title|escape:'html':'UTF-8'}
+{/block}
+
+{block name='page_content'}
+  {if $errors}
+    <ul class="alert alert-danger" role="alert">
+      {foreach from=$errors item=e}<li>{$e|escape:'html':'UTF-8'}</li>{/foreach}
+    </ul>
+  {/if}
+
+  {if $success}
+    <ul class="alert alert-success" role="alert">
+      {foreach from=$success item=s}<li>{$s|escape:'html':'UTF-8'}</li>{/foreach}
+    </ul>
+{/if}
+    <img src="{$oneclick_image_url|escape:'html':'UTF-8'}" alt="Oneclick" class="mb-2" height="50" />
+  {if !$cards|@count}
+    <p>{$strings.no_cards|escape:'html':'UTF-8'}</p>
+  {else}
+    <div class="table-responsive">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>{l s='Tipo' mod='webpay'}</th>
+            <th>{l s='Terminada en' mod='webpay'}</th>
+            <th>{l s='Creada' mod='webpay'}</th>
+            <th>{l s='Acciones' mod='webpay'}</th>
+          </tr>
+        </thead>
+        <tbody>
+        {foreach from=$cards item=card}
+          <tr>
+            <td>{$card.card_type|escape:'html':'UTF-8'}</td>
+            <td>{$card.card_number|escape:'html':'UTF-8'}</td>
+            <td>{$card.created_at|escape:'html':'UTF-8'}</td>
+            <td>
+              <form method="post" action="{$list_url|escape:'html':'UTF-8'}" style="display:inline" onsubmit="return confirm('{l s='¿Eliminar esta tarjeta?' mod='webpay'}');">
+                <input type="hidden" name="id_card" value="{$card.id_card|intval}">
+                <input type="hidden" name="csrf_token" value="{$csrf_token|escape:'html':'UTF-8'}">
+                <input type="submit" class="btn btn-outline-danger btn-sm" value="{$strings.delete|escape:'html':'UTF-8'}">
+              </form>
+            </td>
+          </tr>
+        {/foreach}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+
+  <a class="btn btn-link" href="{$back_to_account_url|escape:'html':'UTF-8'}">{$strings.back|escape:'html':'UTF-8'}</a>
+{/block}

--- a/webpay/views/templates/hook/displayCustomerAccount.tpl
+++ b/webpay/views/templates/hook/displayCustomerAccount.tpl
@@ -1,0 +1,6 @@
+<a class="col-lg-4 col-md-6 col-sm-6 col-xs-12" id="webpay-displayCustomerAccount-link" href="{$oneclickCardsLink}">
+  <span class="link-item">
+    <i class="material-icons">credit_card</i>
+    {l s='Tarjetas Oneclick Inscritas' mod='webpay'}
+  </span>
+</a>

--- a/webpay/webpay.php
+++ b/webpay/webpay.php
@@ -5,6 +5,7 @@ use PrestaShop\Module\WebpayPlus\Config\WebpayConfig;
 use PrestaShop\Module\WebpayPlus\Helpers\InteractsWithWebpayDb;
 use PrestaShop\Module\WebpayPlus\Helpers\InteractsWithTabs;
 use PrestaShop\Module\WebpayPlus\Hooks\DisplayAdminOrderSide;
+use PrestaShop\Module\WebpayPlus\Hooks\DisplayCustomerAccount;
 use PrestaShop\Module\WebpayPlus\Hooks\PaymentOptions;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\Module\WebpayPlus\Helpers\TbkFactory;
@@ -27,7 +28,8 @@ class WebPay extends PaymentModule
         'displayBackOfficeHeader',
         'displayHeader',
         'displayPaymentReturn',
-        'displayAdminOrderSide'
+        'displayAdminOrderSide',
+        'displayCustomerAccount'
     ];
 
     public function __construct()
@@ -136,6 +138,21 @@ class WebPay extends PaymentModule
         } catch (Throwable $e) {
             $this->logError("Error el ejecutar el hook PaymentOptions: {$e->getMessage()}");
             return null;
+        }
+    }
+
+    public function hookDisplayCustomerAccount(): string
+    {
+        try {
+            $displayCustomerAccount = new DisplayCustomerAccount();
+            return $displayCustomerAccount->execute([
+                'module' => $this,
+                'context' => $this->context,
+
+            ]);
+        } catch (Throwable $e) {
+            $this->logError("Error al ejecutar el hook DisplayCustomerAccount: {$e->getMessage()}");
+            return '';
         }
     }
 


### PR DESCRIPTION
This PR add to the customer menu the option to handle Oneclick card.

### Functions
- List oneclick cards.
- Delete a card.

## Tests

### Show option in customer menu
<img width="1106" height="465" alt="image" src="https://github.com/user-attachments/assets/15e6e7ce-7cc3-48a7-90c1-dd34753f8eb3" />

### Show Oneclick cards
<img width="1065" height="397" alt="image" src="https://github.com/user-attachments/assets/fc26228a-90af-40c3-9a73-1f9dff8de2e1" />

### Delete card
<img width="1053" height="406" alt="image" src="https://github.com/user-attachments/assets/55f75717-ad4d-44a2-a63b-ed4cea54daa4" />

### Transaction Ok
<img width="1046" height="1079" alt="image" src="https://github.com/user-attachments/assets/7d01fe94-543b-440c-b2a5-1007cad135d9" />

[plugin-prestashop-webpay-rest-1.0.0.zip](https://github.com/user-attachments/files/22648370/plugin-prestashop-webpay-rest-1.0.0.zip)


