### PR TITLE
feat: add support for PrestaShop 9

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM prestashop/prestashop:9.0.0-8.2
+FROM prestashop/prestashop:9.0.3-8.2
 
 RUN apt-get update && apt-get install -y \
     git \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM prestashop/prestashop:8.2.3-8.1-apache
+FROM prestashop/prestashop:9.0.0-8.2
 
 RUN apt-get update && apt-get install -y \
     git \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -11,7 +11,7 @@ Este devcontainer proporciona un entorno completo de desarrollo para el módulo 
 
 ## 📋 Servicios incluidos
 
--   **PrestaShop 8.2.0** con PHP 8.1.
+-   **PrestaShop 9.0.0** con PHP 8.2.
 -   **MariaDB 10.11** como base de datos.
 -   **Apache** para servir el contenido.
 -   **Extensiones de VS Code** para trabajar con PHP y PrestaShop

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -11,7 +11,7 @@ Este devcontainer proporciona un entorno completo de desarrollo para el módulo 
 
 ## 📋 Servicios incluidos
 
--   **PrestaShop 9.0.0** con PHP 8.2.
+-   **PrestaShop 9.0.3** con PHP 8.2.
 -   **MariaDB 10.11** como base de datos.
 -   **Apache** para servir el contenido.
 -   **Extensiones de VS Code** para trabajar con PHP y PrestaShop
@@ -22,7 +22,7 @@ Este devcontainer proporciona un entorno completo de desarrollo para el módulo 
 | Servicio      | Acceso                          | Credenciales                         |
 | ------------- | ------------------------------- | ------------------------------------ |
 | PrestaShop    | http://localhost:8080           | -                                    |
-| Admin Panel   | http://localhost:8080/adminop   | admin@admin.com / password           |
+| Admin Panel   | http://localhost:8080/admin-dev | admin@admin.com / password           |
 | User Panel    | http://localhost:8080/mi-cuenta | test.user@example.com / Password123! |
 | Base de datos | VS Code SQLTools/MySQL Client   | prestashop / prestashop123           |
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - PS_DOMAIN=localhost:8080
       - ADMIN_MAIL=admin@admin.com
       - ADMIN_PASSWD=password
-      - PS_FOLDER_ADMIN=adminop
+      - PS_FOLDER_ADMIN=admin-dev
       - PS_FOLDER_INSTALL=installop
       - PS_COUNTRY=cl
       - DB_SERVER=db

--- a/.devcontainer/scripts/install-module.sh
+++ b/.devcontainer/scripts/install-module.sh
@@ -22,6 +22,7 @@ TEST_ADDRESS2="Demo Adress 2"
 TEST_CITY="Santiago"
 TEST_POSTCODE="750-0000"
 TEST_PHONE="12345678"
+TEST_PHONE_MOBILE="12345678"
 
 TEST_PASS_HASH="$(php -r 'echo password_hash(getenv("P") ?: "Password123!", PASSWORD_BCRYPT);' P="$TEST_PASSWORD_PLAIN")"
 
@@ -55,18 +56,23 @@ SET @id_country := IFNULL(@id_country, 1);
 
 -- Crear dirección si el cliente no tiene alguna
 INSERT INTO ps_address (
-  id_customer, id_country, alias, company, firstname, lastname,
-  address1, address2, city, postcode, phone, active, date_add, date_upd
+  id_customer, id_country, id_state, id_manufacturer, id_supplier, id_warehouse,
+  alias, company, firstname, lastname, address1, address2, city, postcode,
+  phone, phone_mobile, vat_number, dni, other, active, deleted, date_add, date_upd
 )
 SELECT
-  @cid, @id_country, 'Home', '', '$TEST_FIRSTNAME', '$TEST_LASTNAME',
-  '$TEST_ADDRESS1', '$TEST_ADDRESS2', '$TEST_CITY', '$TEST_POSTCODE', '$TEST_PHONE', 1, NOW(), NOW()
+  @cid, @id_country, NULL, 0, 0, 0,
+  'Home', '', '$TEST_FIRSTNAME', '$TEST_LASTNAME', '$TEST_ADDRESS1', '$TEST_ADDRESS2', '$TEST_CITY', '$TEST_POSTCODE',
+  '$TEST_PHONE', '$TEST_PHONE_MOBILE', NULL, NULL, NULL, 1, 0, NOW(), NOW()
 WHERE NOT EXISTS (SELECT 1 FROM ps_address WHERE id_customer = @cid LIMIT 1);
 SQL
 
 echo "* [Prestashop] Configurando Smarty para dev..."
 su -s /bin/bash www-data -c "php /var/www/html/bin/console dbal:run-sql \"UPDATE ps_configuration SET value=0 WHERE name='PS_SMARTY_CACHE'\""
 su -s /bin/bash www-data -c "php /var/www/html/bin/console dbal:run-sql \"UPDATE ps_configuration SET value=1 WHERE name='PS_SMARTY_FORCE_COMPILE'\""
+
+echo "* [webpay] Corrigiendo permisos de vendor..."
+chown -R www-data:www-data /var/www/html/modules/webpay/vendor
 
 echo "* [webpay] Installing module webpay..."
 su -s /bin/bash www-data -c "php /var/www/html/bin/console prestashop:module --no-interaction install webpay"

--- a/.devcontainer/scripts/install-module.sh
+++ b/.devcontainer/scripts/install-module.sh
@@ -18,6 +18,7 @@ TEST_FIRSTNAME="Test"
 TEST_LASTNAME="User"
 TEST_PASSWORD_PLAIN="Password123!"
 TEST_ADDRESS1="Av. Demo 123"
+TEST_ADDRESS2="Demo Adress 2"
 TEST_CITY="Santiago"
 TEST_POSTCODE="750-0000"
 TEST_PHONE="12345678"
@@ -55,11 +56,11 @@ SET @id_country := IFNULL(@id_country, 1);
 -- Crear dirección si el cliente no tiene alguna
 INSERT INTO ps_address (
   id_customer, id_country, alias, company, firstname, lastname,
-  address1, city, postcode, phone, active, date_add, date_upd
+  address1, address2, city, postcode, phone, active, date_add, date_upd
 )
 SELECT
   @cid, @id_country, 'Home', '', '$TEST_FIRSTNAME', '$TEST_LASTNAME',
-  '$TEST_ADDRESS1', '$TEST_CITY', '$TEST_POSTCODE', '$TEST_PHONE', 1, NOW(), NOW()
+  '$TEST_ADDRESS1', '$TEST_ADDRESS2', '$TEST_CITY', '$TEST_POSTCODE', '$TEST_PHONE', 1, NOW(), NOW()
 WHERE NOT EXISTS (SELECT 1 FROM ps_address WHERE id_customer = @cid LIMIT 1);
 SQL
 

--- a/.github/workflows/kiuwan.yml
+++ b/.github/workflows/kiuwan.yml
@@ -10,6 +10,7 @@ jobs:
     with:
       project_name: td-webpay-plugin-prestashop
       source_path: .
+      fail_on_audit: true
     secrets:
       VPN_CONFIG_B64: ${{ secrets.VPN_CONFIG_B64 }}
       VPN_USER: ${{ secrets.VPN_USER }}

--- a/.github/workflows/kiuwan.yml
+++ b/.github/workflows/kiuwan.yml
@@ -1,0 +1,18 @@
+name: Kiuwan
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  scan:
+    uses: TransbankDevelopers/transbank-github-actions-templates/.github/workflows/kiuwan-pr-scan.yml@main
+    with:
+      project_name: td-webpay-plugin-prestashop
+      source_path: .
+    secrets:
+      VPN_CONFIG_B64: ${{ secrets.VPN_CONFIG_B64 }}
+      VPN_USER: ${{ secrets.VPN_USER }}
+      VPN_PASS: ${{ secrets.VPN_PASS }}
+      KIUWAN_USER: ${{ secrets.KIUWAN_USER }}
+      KIUWAN_PASS: ${{ secrets.KIUWAN_PASS }}

--- a/.github/workflows/kiuwan.yml
+++ b/.github/workflows/kiuwan.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   scan:
-    uses: TransbankDevelopers/transbank-github-actions-templates/.github/workflows/kiuwan-pr-scan.yml@main
+    uses: TransbankDevelopers/transbank-github-actions-templates/.github/workflows/kiuwan-pr-scan.yml@b853e0ad1650c5d13357a915a9ad4ddc43803ae0
     with:
       project_name: td-webpay-plugin-prestashop
       source_path: .

--- a/.github/workflows/kiuwan.yml
+++ b/.github/workflows/kiuwan.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   scan:
-    uses: TransbankDevelopers/transbank-github-actions-templates/.github/workflows/kiuwan-pr-scan.yml@b853e0ad1650c5d13357a915a9ad4ddc43803ae0
+    uses: TransbankDevelopers/transbank-github-actions-templates/.github/workflows/kiuwan-pr-scan.yml@9f01e2b64825c3744d85b41ba2486049904d199c
     with:
       project_name: td-webpay-plugin-prestashop
       source_path: .

--- a/.github/workflows/kiuwan.yml
+++ b/.github/workflows/kiuwan.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   scan:
-    uses: TransbankDevelopers/transbank-github-actions-templates/.github/workflows/kiuwan-pr-scan.yml@9f01e2b64825c3744d85b41ba2486049904d199c
+    uses: TransbankDevelopers/transbank-github-actions-templates/.github/workflows/kiuwan-pr-scan.yml@2a2837602d7636c5f31f97209ae60a0fe74c2c94
     with:
       project_name: td-webpay-plugin-prestashop
       source_path: .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,23 +10,15 @@ jobs:
   run:
     runs-on: ubuntu-latest
     permissions: write-all
-    strategy:
-      matrix:
-        php-versions: ['7.4', '8.0']
-    name: PHP ${{ matrix.php-versions }}
+    name: PHP 8.2
     steps:
       - uses: actions/checkout@v3
       - name: 1. Install dependencies 
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: '8.2'
       - run: |
           cd webpay
-          if [ "${{ matrix.php-versions }}" = "8.0" ]
-          then
-            sed -i.bkp "s/\"php\": \"7.0\"/\"php\": \"8.0\"/g" "composer.json"
-            composer require guzzlehttp/guzzle:^7.0
-          fi
           composer update --no-dev
           composer install --no-dev
       - name: 2. Replace versión
@@ -39,12 +31,12 @@ jobs:
         uses: thedoctor0/zip-release@0.7.1
         with:
           type: 'zip'
-          filename: 'plugin-prestashop${{ matrix.php-versions }}-webpay-rest-${{github.ref_name}}.zip'
+          filename: 'plugin-prestashop8.2-webpay-rest-${{github.ref_name}}.zip'
           path: './webpay'    
       - name: 4. Upload binaries to release
         uses: svenstaro/upload-release-action@2.5.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: './plugin-prestashop${{ matrix.php-versions }}-webpay-rest-${{github.ref_name}}.zip'
+          file: './plugin-prestashop8.2-webpay-rest-${{github.ref_name}}.zip'
           tag: ${{ github.ref }}
           overwrite: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   run:
@@ -13,10 +13,10 @@ jobs:
     name: PHP 8.2
     steps:
       - uses: actions/checkout@v3
-      - name: 1. Install dependencies 
+      - name: 1. Install dependencies
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: "8.2"
       - run: |
           cd webpay
           composer update --no-dev
@@ -30,13 +30,13 @@ jobs:
       - name: 3. Archive Release
         uses: thedoctor0/zip-release@0.7.1
         with:
-          type: 'zip'
-          filename: 'plugin-prestashop8.2-webpay-rest-${{github.ref_name}}.zip'
-          path: './webpay'    
+          type: "zip"
+          filename: "plugin-prestashop8.2-webpay-rest-${{github.ref_name}}.zip"
+          path: "./webpay"
       - name: 4. Upload binaries to release
         uses: svenstaro/upload-release-action@2.5.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: './plugin-prestashop8.2-webpay-rest-${{github.ref_name}}.zip'
+          file: "./plugin-prestashop8.2-webpay-rest-${{github.ref_name}}.zip"
           tag: ${{ github.ref }}
           overwrite: true

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ A continuación, encontrarás información necesaria para el desarrollo de este 
 
 # Requisitos
 
--   PHP 8.1+ o superior
--   PrestaShop 1.7.8.0 o superior
+-   PHP 8.2 o superior
+-   PrestaShop 9.0.0 o superior
 
 # Dependencias
 

--- a/webpay/composer.json
+++ b/webpay/composer.json
@@ -1,13 +1,13 @@
 {
     "require": {
-        "transbank/transbank-sdk": "~4.0",
-        "monolog/monolog": "^1.27.1",
+        "transbank/transbank-sdk": "~5.0",
+        "monolog/monolog": "^2.0",
         "ext-json": "*",
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "config": {
         "platform": {
-            "php": "8.1"
+            "php": "8.2"
         }
     },
     "autoload": {

--- a/webpay/config/routes.yml
+++ b/webpay/config/routes.yml
@@ -61,7 +61,7 @@ ps_controller_webpay_transaction_list_search:
   path: /webpay/transaction-list
   methods: [POST]
   defaults:
-    _controller: PrestaShopBundle:Admin\Common:searchGrid
+    _controller: 'PrestaShopBundle\Controller\Admin\CommonController::searchGridAction'
     gridDefinitionFactoryServiceId: webpay.grid.definition.factory.transactions_grid_definition_factory
     redirectRoute: ps_controller_webpay_transaction_list
     _legacy_controller: WebpayPlusConfigure
@@ -77,7 +77,7 @@ ps_controller_webpay_oneclick_cards_list_search:
   path: /webpay/oneclick-cards-list
   methods: [POST]
   defaults:
-    _controller: PrestaShopBundle:Admin\Common:searchGrid
+    _controller: 'PrestaShopBundle\Controller\Admin\CommonController::searchGridAction'
     gridDefinitionFactoryServiceId: webpay.grid.definition.factory.oneclick_card_grid_definition_factory
     redirectRoute: ps_controller_webpay_oneclick_cards_list
     _legacy_controller: WebpayPlusConfigure

--- a/webpay/config/services.yml
+++ b/webpay/config/services.yml
@@ -127,3 +127,10 @@ services:
       - "@webpay.grid.data.factory.oneclick_card_data_factory"
       - "@prestashop.core.grid.filter.form_factory"
       - "@prestashop.core.hook.dispatcher"
+
+  # Admin Controllers
+  PrestaShop\Module\WebpayPlus\Controller\Admin\:
+    resource: "../src/Controller/Admin/"
+    autowire: true
+    autoconfigure: true
+    public: true

--- a/webpay/config/services.yml
+++ b/webpay/config/services.yml
@@ -68,6 +68,8 @@ services:
     class: 'PrestaShop\Module\WebpayPlus\Grid\TransactionsGridDefinitionFactory'
     parent: "prestashop.core.grid.definition.factory.abstract_grid_definition"
     public: true
+    tags:
+      - { name: core.grid_definition_factory }
 
   webpay.grid.query.transactions_query_builder:
     class: 'PrestaShop\Module\WebpayPlus\Grid\TransactionsQueryBuilder'
@@ -99,6 +101,8 @@ services:
     class: 'PrestaShop\Module\WebpayPlus\Grid\OneclickCards\OneclickCardGridDefinitionFactory'
     parent: "prestashop.core.grid.definition.factory.abstract_grid_definition"
     public: true
+    tags:
+      - { name: core.grid_definition_factory }
 
   webpay.grid.query.oneclick_card_query_builder:
     class: 'PrestaShop\Module\WebpayPlus\Grid\OneclickCards\OneclickCardQueryBuilder'

--- a/webpay/controllers/front/oneclickcards.php
+++ b/webpay/controllers/front/oneclickcards.php
@@ -31,7 +31,7 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
     /** @var string */
     private $environment;
 
-    /** @var PrestaShop\Module\WebpayPlus\Utils\OrderUtils */
+    /** @var PrestaShop\Module\WebpayPlus\Utils\Utils */
     private $moduleUtils;
 
     /**

--- a/webpay/controllers/front/oneclickcards.php
+++ b/webpay/controllers/front/oneclickcards.php
@@ -69,7 +69,7 @@ class WebPayOneclickCardsModuleFrontController extends ModuleFrontController
             }
 
             $this->handleCardRequest();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $this->errors[] = "La operación no se pudo completar, por favor reintente. En caso de persistir el problema, contacte al comercio.";
             $this->log->logError($e->getMessage());
             return;

--- a/webpay/controllers/front/oneclickinscriptionvalidate.php
+++ b/webpay/controllers/front/oneclickinscriptionvalidate.php
@@ -47,20 +47,25 @@ class WebPayOneclickInscriptionValidateModuleFrontController extends BaseModuleF
         Tools::redirect('index.php?controller=order');
     }
 
-    private function finishInscription($ins, $token){
+    private function finishInscription($ins, $token)
+    {
         $webpay = OneclickFactory::create();
         try {
-            $resp = $webpay->finish($token, $ins->username, $ins->email);
+            $resp = $webpay->finish($token, $ins['username'], $ins['email']);
         } catch (\Exception $e) {
             $this->setPaymentErrorPage($e->getMessage());
         }
-        $ins->finished = true;
-        $ins->authorization_code = $resp->getAuthorizationCode();
-        $ins->tbk_token = $resp->getTbkUser();
-        $ins->card_type = $resp->getCardType();
-        $ins->card_number = $resp->getCardNumber();
-        $ins->transbank_response = json_encode($resp);
-        $ins->status = $resp->isApproved() ? TransbankInscriptions::STATUS_COMPLETED : TransbankInscriptions::STATUS_FAILED;
-        $ins->save();
+
+        $this->inscriptionRepository->updateById($ins['id'], [
+            'finished'           => true,
+            'authorization_code' => $resp->getAuthorizationCode(),
+            'tbk_token'          => $resp->getTbkUser(),
+            'card_type'          => $resp->getCardType(),
+            'card_number'        => $resp->getCardNumber(),
+            'transbank_response' => json_encode($resp),
+            'status'             => $resp->isApproved()
+                ? TransbankInscriptions::STATUS_COMPLETED
+                : TransbankInscriptions::STATUS_FAILED,
+        ]);
     }
 }

--- a/webpay/shared/Helpers/InfoUtil.php
+++ b/webpay/shared/Helpers/InfoUtil.php
@@ -12,8 +12,8 @@ class InfoUtil
     public static function getValidatephp()
     {
         if (
-            version_compare(phpversion(), '7.4.33', '<=') &&
-            version_compare(phpversion(), '7.0.0', '>=')
+            version_compare(phpversion(), '8.3', '<') &&
+            version_compare(phpversion(), '8.2.0', '>=')
         ) {
             return [
                 'status' => 'OK',

--- a/webpay/src/Config/OneclickConfig.php
+++ b/webpay/src/Config/OneclickConfig.php
@@ -94,9 +94,9 @@ class OneclickConfig extends AbstractModuleConfig
     {
         self::setPaymentActive(TbkConstants::ACTIVE_MODULE);
         self::setEnvironment(Options::ENVIRONMENT_INTEGRATION);
-        self::setCommerceCode(Oneclick::DEFAULT_COMMERCE_CODE);
-        self::setChildCommerceCode(Oneclick::DEFAULT_CHILD_COMMERCE_CODE_1);
-        self::setApiKey(Oneclick::DEFAULT_API_KEY);
+        self::setCommerceCode(Oneclick::INTEGRATION_COMMERCE_CODE);
+        self::setChildCommerceCode(Oneclick::INTEGRATION_CHILD_COMMERCE_CODE_1);
+        self::setApiKey(Oneclick::INTEGRATION_API_KEY);
         self::setOrderStateIdAfterPayment(Configuration::get('PS_OS_PREPARATION'));
     }
 

--- a/webpay/src/Config/WebpayConfig.php
+++ b/webpay/src/Config/WebpayConfig.php
@@ -7,7 +7,6 @@ use Transbank\Webpay\Options;
 use Transbank\Webpay\WebpayPlus;
 use Transbank\Plugin\Helpers\TbkConstants;
 use PrestaShop\Module\WebpayPlus\Utils\StringUtils;
-use PrestaShop\Module\WebpayPlus\Config\ModuleConfigInterface;
 
 class WebpayConfig extends AbstractModuleConfig
 {
@@ -75,8 +74,8 @@ class WebpayConfig extends AbstractModuleConfig
     {
         self::setPaymentActive(TbkConstants::ACTIVE_MODULE);
         self::setEnvironment(Options::ENVIRONMENT_INTEGRATION);
-        self::setCommerceCode(WebpayPlus::DEFAULT_COMMERCE_CODE);
-        self::setApiKey(WebpayPlus::DEFAULT_API_KEY);
+        self::setCommerceCode(WebpayPlus::INTEGRATION_COMMERCE_CODE);
+        self::setApiKey(WebpayPlus::INTEGRATION_API_KEY);
         self::setOrderStateIdAfterPayment(Configuration::get('PS_OS_PREPARATION'));
     }
 

--- a/webpay/src/Controller/Admin/ConfigureController.php
+++ b/webpay/src/Controller/Admin/ConfigureController.php
@@ -101,27 +101,13 @@ class ConfigureController extends PrestaShopAdminController
         #[Autowire(service: 'webpay.form.webpay_plus_form_data_handler')]
         FormHandlerInterface $formDataHandler,
     ): Response {
-        $form = $formDataHandler->getForm();
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted()) {
-            if ($form->getClickedButton() === $form->get('webpay_plus_form_reset_button')) {
-                WebpayConfig::loadDefaultConfig();
-                $this->addFlash('success', $this->trans(self::SUCCESSFUL_UPDATE, [], 'Admin.Notifications.Success'));
-            } elseif (!$form->isValid()) {
-                foreach ($form->getErrors() as $error) {
-                    $errors[] = $error->getMessage();
-                }
-                $this->addFlashErrors($errors);
-            } elseif ($form->getClickedButton() === $form->get('webpay_plus_form_save_button')) {
-                $errors = $formDataHandler->save($form->getData());
-                if (empty($errors)) {
-                    $this->addFlash('success', $this->trans(self::SUCCESSFUL_UPDATE, [], 'Admin.Notifications.Success'));
-                } else {
-                    $this->addFlashErrors($errors);
-                }
-            }
-        }
+        $this->handleFormSubmission(
+            $request,
+            $formDataHandler,
+            'webpay_plus_form_reset_button',
+            'webpay_plus_form_save_button',
+            fn() => WebpayConfig::loadDefaultConfig()
+        );
 
         return $this->redirectToRoute('ps_controller_webpay_configure_webpayplus');
     }
@@ -132,28 +118,54 @@ class ConfigureController extends PrestaShopAdminController
         #[Autowire(service: 'webpay.form.oneclick_form_data_handler')]
         FormHandlerInterface $formDataHandler,
     ): Response {
+        $this->handleFormSubmission(
+            $request,
+            $formDataHandler,
+            'oneclick_form_reset_button',
+            'oneclick_form_save_button',
+            fn() => OneclickConfig::loadDefaultConfig()
+        );
+
+        return $this->redirectToRoute('ps_controller_webpay_configure_oneclick');
+    }
+
+    private function handleFormSubmission(
+        Request $request,
+        FormHandlerInterface $formDataHandler,
+        string $resetButtonName,
+        string $saveButtonName,
+        callable $onReset
+    ): void {
         $form = $formDataHandler->getForm();
         $form->handleRequest($request);
 
-        if ($form->isSubmitted()) {
-            if ($form->getClickedButton() === $form->get('oneclick_form_reset_button')) {
-                OneclickConfig::loadDefaultConfig();
-                $this->addFlash('success', $this->trans(self::SUCCESSFUL_UPDATE, [], 'Admin.Notifications.Success'));
-            } elseif (!$form->isValid()) {
-                foreach ($form->getErrors() as $error) {
-                    $errors[] = $error->getMessage();
-                }
-                $this->addFlashErrors($errors);
-            } elseif ($form->getClickedButton() === $form->get('oneclick_form_save_button')) {
-                $errors = $formDataHandler->save($form->getData());
-                if (empty($errors)) {
-                    $this->addFlash('success', $this->trans(self::SUCCESSFUL_UPDATE, [], 'Admin.Notifications.Success'));
-                } else {
-                    $this->addFlashErrors($errors);
-                }
-            }
+        if (!$form->isSubmitted()) {
+            return;
         }
 
-        return $this->redirectToRoute('ps_controller_webpay_configure_oneclick');
+        if ($form->getClickedButton() === $form->get($resetButtonName)) {
+            $onReset();
+            $this->addFlash('success', $this->trans(self::SUCCESSFUL_UPDATE, [], 'Admin.Notifications.Success'));
+            return;
+        }
+
+        if (!$form->isValid()) {
+            $errors = [];
+            foreach ($form->getErrors() as $error) {
+                $errors[] = $error->getMessage();
+            }
+
+            $this->addFlashErrors($errors);
+            return;
+        }
+
+        if ($form->getClickedButton() === $form->get($saveButtonName)) {
+            $errors = $formDataHandler->save($form->getData());
+            if (empty($errors)) {
+                $this->addFlash('success', $this->trans(self::SUCCESSFUL_UPDATE, [], 'Admin.Notifications.Success'));
+            } else {
+                $this->addFlashErrors($errors);
+            }
+        }
     }
 }

--- a/webpay/src/Controller/Admin/ConfigureController.php
+++ b/webpay/src/Controller/Admin/ConfigureController.php
@@ -6,7 +6,6 @@ namespace PrestaShop\Module\WebpayPlus\Controller\Admin;
 
 use PrestaShop\Module\WebpayPlus\Config\OneclickConfig;
 use Symfony\Component\HttpFoundation\Request;
-use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Response;
 use PrestaShop\Module\WebpayPlus\Helpers\TbkFactory;
@@ -14,31 +13,36 @@ use Transbank\Plugin\Helpers\InfoUtil;
 use Transbank\Plugin\Helpers\PrestashopInfoUtil;
 use PrestaShop\Module\WebpayPlus\Grid\TransactionsFilters;
 use PrestaShop\Module\WebpayPlus\Config\WebpayConfig;
+use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
 
-
-class ConfigureController extends FrameworkBundleAdminController
+class ConfigureController extends PrestaShopAdminController
 {
     const TAB_CLASS_NAME = 'WebpayPlusConfigure';
 
     /** @Route("/webpay/configure", name="webpayplus") */
-    public function webpayplusAction()
-    {
-        $webpayPlusFormDataHandler = $this->get('webpay.form.webpay_plus_form_data_handler');
+    public function webpayplusAction(
+        #[Autowire(service: 'webpay.form.webpay_plus_form_data_handler')]
+        FormHandlerInterface $webpayPlusFormDataHandler,
+    ): Response {
         $webpayPlusForm = $webpayPlusFormDataHandler->getForm();
 
         return $this->render('@Modules/webpay/views/templates/admin/webpay_configure.html.twig', [
             'webpayPlusForm' => $webpayPlusForm->createView(),
             'enableSidebar' => true,
-            'layoutTitle' => $this->trans('Configuración Webpay', 'Modules.WebpayPlus.Admin')
+            'layoutTitle' => $this->trans('Configuración Webpay', [], 'Modules.WebpayPlus.Admin')
         ]);
     }
 
     /** @Route("/webpay/transaction-list", name="transactionList") */
     public function transactionListAction(
         Request $request,
-        TransactionsFilters $transactionsFilters
-    ) {
-        $productGridFactory = $this->get('webpay.grid.transactions_grid_factory');
+        TransactionsFilters $transactionsFilters,
+        #[Autowire(service: 'webpay.grid.transactions_grid_factory')]
+        GridFactoryInterface $productGridFactory,
+    ): Response {
         $productGrid = $productGridFactory->getGrid($transactionsFilters);
 
         return $this->render('@Modules/webpay/views/templates/admin/transaction_list.html.twig', [
@@ -49,67 +53,70 @@ class ConfigureController extends FrameworkBundleAdminController
     }
 
     /** @Route("/webpay/configure", name="oneclick") */
-    public function oneclickAction()
-    {
-        $oneclickFormDataHandler = $this->get('webpay.form.oneclick_form_data_handler');
+    public function oneclickAction(
+        #[Autowire(service: 'webpay.form.oneclick_form_data_handler')]
+        FormHandlerInterface $oneclickFormDataHandler,
+    ): Response {
         $oneclickForm = $oneclickFormDataHandler->getForm();
 
         return $this->render('@Modules/webpay/views/templates/admin/oneclick_configure.html.twig', [
             'oneclickForm' => $oneclickForm->createView(),
             'enableSidebar' => true,
-            'layoutTitle' => $this->trans('Configuración Webpay', 'Modules.WebpayPlus.Admin')
+            'layoutTitle' => $this->trans('Configuración Webpay', [], 'Modules.WebpayPlus.Admin')
         ]);
     }
 
     /** @Route("/webpay/configure", name="diagnosis") */
-    public function diagnosisAction()
+    public function diagnosisAction(): Response
     {
         $summary = InfoUtil::getSummary();
         $eSummary = PrestashopInfoUtil::getSummary();
         return $this->render('@Modules/webpay/views/templates/admin/diagnosis_configure.html.twig', [
             'enableSidebar' => true,
-            'layoutTitle' => $this->trans('Configuración Webpay', 'Modules.WebpayPlus.Admin'),
+            'layoutTitle' => $this->trans('Configuración Webpay', [], 'Modules.WebpayPlus.Admin'),
             'summary' => $summary,
             'eSummary' => $eSummary
         ]);
     }
 
     /** @Route("/webpay/configure", name="logs") */
-    public function logsAction()
+    public function logsAction(): Response
     {
         $logger = TbkFactory::createLogger();
         $resume = $logger->getInfo();
         $lastLog = $logger->getLogDetail(basename($resume['last']));
         return $this->render('@Modules/webpay/views/templates/admin/logs_configure.html.twig', [
             'enableSidebar' => true,
-            'layoutTitle' => $this->trans('Configuración Webpay', 'Modules.WebpayPlus.Admin'),
+            'layoutTitle' => $this->trans('Configuración Webpay', [], 'Modules.WebpayPlus.Admin'),
             'resume' => $resume,
             'lastLog' => $lastLog
         ]);
     }
 
     /** @Route("/webpay/configure", name="saveWebpayPlusForm") */
-    public function saveWebpayPlusFormAction(Request $request): Response
-    {
-        $formDataHandler = $this->get('webpay.form.webpay_plus_form_data_handler');
+    public function saveWebpayPlusFormAction(
+        Request $request,
+        #[Autowire(service: 'webpay.form.webpay_plus_form_data_handler')]
+        FormHandlerInterface $formDataHandler,
+    ): Response {
         $form = $formDataHandler->getForm();
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
             if ($form->getClickedButton() === $form->get('webpay_plus_form_reset_button')) {
                 WebpayConfig::loadDefaultConfig();
-                $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+                $this->addFlash('success', $this->trans('Successful update.', [], 'Admin.Notifications.Success'));
             } elseif (!$form->isValid()) {
                 foreach ($form->getErrors() as $error) {
                     $errors[] = $error->getMessage();
                 }
-                $this->flashErrors($errors);
+                $this->addFlashErrors($errors);
             } elseif ($form->getClickedButton() === $form->get('webpay_plus_form_save_button')) {
                 $errors = $formDataHandler->save($form->getData());
                 if (empty($errors)) {
-                    $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+                    $this->addFlash('success', $this->trans('Successful update.', [], 'Admin.Notifications.Success'));
                 } else {
-                    $this->flashErrors($errors);
+                    $this->addFlashErrors($errors);
                 }
             }
         }
@@ -118,32 +125,33 @@ class ConfigureController extends FrameworkBundleAdminController
     }
 
     /** @Route("/webpay/configure", name="saveOneclickForm") */
-    public function saveOneclickFormAction(Request $request): Response
-    {
-        $formDataHandler = $this->get('webpay.form.oneclick_form_data_handler');
+    public function saveOneclickFormAction(
+        Request $request,
+        #[Autowire(service: 'webpay.form.oneclick_form_data_handler')]
+        FormHandlerInterface $formDataHandler,
+    ): Response {
         $form = $formDataHandler->getForm();
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
             if ($form->getClickedButton() === $form->get('oneclick_form_reset_button')) {
                 OneclickConfig::loadDefaultConfig();
-                $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+                $this->addFlash('success', $this->trans('Successful update.', [], 'Admin.Notifications.Success'));
             } elseif (!$form->isValid()) {
                 foreach ($form->getErrors() as $error) {
                     $errors[] = $error->getMessage();
                 }
-                $this->flashErrors($errors);
+                $this->addFlashErrors($errors);
             } elseif ($form->getClickedButton() === $form->get('oneclick_form_save_button')) {
                 $errors = $formDataHandler->save($form->getData());
                 if (empty($errors)) {
-                    $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
+                    $this->addFlash('success', $this->trans('Successful update.', [], 'Admin.Notifications.Success'));
                 } else {
-                    $this->flashErrors($errors);
+                    $this->addFlashErrors($errors);
                 }
             }
         }
 
         return $this->redirectToRoute('ps_controller_webpay_configure_oneclick');
     }
-
 }

--- a/webpay/src/Controller/Admin/ConfigureController.php
+++ b/webpay/src/Controller/Admin/ConfigureController.php
@@ -21,6 +21,8 @@ use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
 class ConfigureController extends PrestaShopAdminController
 {
     const TAB_CLASS_NAME = 'WebpayPlusConfigure';
+    const LAYOUT_TITLE = 'Configuración Webpay';
+    const SUCCESSFUL_UPDATE = 'Successful update.';
 
     /** @Route("/webpay/configure", name="webpayplus") */
     public function webpayplusAction(
@@ -32,7 +34,7 @@ class ConfigureController extends PrestaShopAdminController
         return $this->render('@Modules/webpay/views/templates/admin/webpay_configure.html.twig', [
             'webpayPlusForm' => $webpayPlusForm->createView(),
             'enableSidebar' => true,
-            'layoutTitle' => $this->trans('Configuración Webpay', [], 'Modules.WebpayPlus.Admin')
+            'layoutTitle' => $this->trans(self::LAYOUT_TITLE, [], 'Modules.WebpayPlus.Admin')
         ]);
     }
 
@@ -62,7 +64,7 @@ class ConfigureController extends PrestaShopAdminController
         return $this->render('@Modules/webpay/views/templates/admin/oneclick_configure.html.twig', [
             'oneclickForm' => $oneclickForm->createView(),
             'enableSidebar' => true,
-            'layoutTitle' => $this->trans('Configuración Webpay', [], 'Modules.WebpayPlus.Admin')
+            'layoutTitle' => $this->trans(self::LAYOUT_TITLE, [], 'Modules.WebpayPlus.Admin')
         ]);
     }
 
@@ -73,7 +75,7 @@ class ConfigureController extends PrestaShopAdminController
         $eSummary = PrestashopInfoUtil::getSummary();
         return $this->render('@Modules/webpay/views/templates/admin/diagnosis_configure.html.twig', [
             'enableSidebar' => true,
-            'layoutTitle' => $this->trans('Configuración Webpay', [], 'Modules.WebpayPlus.Admin'),
+            'layoutTitle' => $this->trans(self::LAYOUT_TITLE, [], 'Modules.WebpayPlus.Admin'),
             'summary' => $summary,
             'eSummary' => $eSummary
         ]);
@@ -87,7 +89,7 @@ class ConfigureController extends PrestaShopAdminController
         $lastLog = $logger->getLogDetail(basename($resume['last']));
         return $this->render('@Modules/webpay/views/templates/admin/logs_configure.html.twig', [
             'enableSidebar' => true,
-            'layoutTitle' => $this->trans('Configuración Webpay', [], 'Modules.WebpayPlus.Admin'),
+            'layoutTitle' => $this->trans(self::LAYOUT_TITLE, [], 'Modules.WebpayPlus.Admin'),
             'resume' => $resume,
             'lastLog' => $lastLog
         ]);
@@ -105,7 +107,7 @@ class ConfigureController extends PrestaShopAdminController
         if ($form->isSubmitted()) {
             if ($form->getClickedButton() === $form->get('webpay_plus_form_reset_button')) {
                 WebpayConfig::loadDefaultConfig();
-                $this->addFlash('success', $this->trans('Successful update.', [], 'Admin.Notifications.Success'));
+                $this->addFlash('success', $this->trans(self::SUCCESSFUL_UPDATE, [], 'Admin.Notifications.Success'));
             } elseif (!$form->isValid()) {
                 foreach ($form->getErrors() as $error) {
                     $errors[] = $error->getMessage();
@@ -114,7 +116,7 @@ class ConfigureController extends PrestaShopAdminController
             } elseif ($form->getClickedButton() === $form->get('webpay_plus_form_save_button')) {
                 $errors = $formDataHandler->save($form->getData());
                 if (empty($errors)) {
-                    $this->addFlash('success', $this->trans('Successful update.', [], 'Admin.Notifications.Success'));
+                    $this->addFlash('success', $this->trans(self::SUCCESSFUL_UPDATE, [], 'Admin.Notifications.Success'));
                 } else {
                     $this->addFlashErrors($errors);
                 }
@@ -136,7 +138,7 @@ class ConfigureController extends PrestaShopAdminController
         if ($form->isSubmitted()) {
             if ($form->getClickedButton() === $form->get('oneclick_form_reset_button')) {
                 OneclickConfig::loadDefaultConfig();
-                $this->addFlash('success', $this->trans('Successful update.', [], 'Admin.Notifications.Success'));
+                $this->addFlash('success', $this->trans(self::SUCCESSFUL_UPDATE, [], 'Admin.Notifications.Success'));
             } elseif (!$form->isValid()) {
                 foreach ($form->getErrors() as $error) {
                     $errors[] = $error->getMessage();
@@ -145,7 +147,7 @@ class ConfigureController extends PrestaShopAdminController
             } elseif ($form->getClickedButton() === $form->get('oneclick_form_save_button')) {
                 $errors = $formDataHandler->save($form->getData());
                 if (empty($errors)) {
-                    $this->addFlash('success', $this->trans('Successful update.', [], 'Admin.Notifications.Success'));
+                    $this->addFlash('success', $this->trans(self::SUCCESSFUL_UPDATE, [], 'Admin.Notifications.Success'));
                 } else {
                     $this->addFlashErrors($errors);
                 }

--- a/webpay/src/Controller/Admin/OneclickCardsController.php
+++ b/webpay/src/Controller/Admin/OneclickCardsController.php
@@ -5,53 +5,54 @@ declare(strict_types=1);
 namespace PrestaShop\Module\WebpayPlus\Controller\Admin;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
-use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Response;
 use PrestaShop\Module\WebpayPlus\Grid\OneclickCards\OneclickCardsFilters;
 use PrestaShop\Module\WebpayPlus\Repository\InscriptionRepository;
 use PrestaShop\Module\WebpayPlus\Helpers\OneclickFactory;
 use Transbank\Plugin\Exceptions\EcommerceException;
 use PrestaShop\Module\WebpayPlus\Helpers\TbkFactory;
+use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
+use PrestaShopBundle\Security\Attribute\AdminSecurity;
+use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Routing\Attribute\Route;
 
-
-class OneclickCardsController extends FrameworkBundleAdminController
+class OneclickCardsController extends PrestaShopAdminController
 {
     protected function getTabClassName(): string
     {
         return ConfigureController::TAB_CLASS_NAME;
     }
 
-    /**
-     * @Route("/webpay/oneclick-cards-list", name="oneclick-cards-list")
-     * @AdminSecurity(
-     *     "is_granted('ROLE_MOD_TAB_WEBPAYPLUSCONFIGURE_READ')",
-     *     redirectRoute="admin_login"
-     * )
-     */
-    public function oneclickCardsListAction(OneclickCardsFilters $filters): Response
-    {
-        $gridFactory = $this->get('webpay.grid.oneclick_card_grid_factory');
-
+    #[Route("/webpay/oneclick-cards-list", name: "oneclick-cards-list")]
+    #[AdminSecurity(
+        "is_granted('ROLE_MOD_TAB_WEBPAYPLUSCONFIGURE_READ')",
+        redirectRoute: "admin_login"
+    )]
+    public function oneclickCardsListAction(
+        OneclickCardsFilters $filters,
+        #[Autowire(service: 'webpay.grid.oneclick_card_grid_factory')]
+        GridFactoryInterface $gridFactory,
+    ): Response {
         $cardsGrid = $gridFactory->getGrid($filters);
         return $this->render('@Modules/webpay/views/templates/admin/oneclick_cards_list.html.twig', [
             'cardsGrid' => $this->presentGrid($cardsGrid),
             'enableSidebar' => true,
-            'layoutTitle' => $this->trans('Tarjetas Oneclick', 'Modules.WebpayPlus.Admin')
+            'layoutTitle' => $this->trans('Tarjetas Oneclick', [], 'Modules.WebpayPlus.Admin')
         ]);
     }
 
-    /**
-     * @AdminSecurity(
-     *     "is_granted('ROLE_MOD_TAB_WEBPAYPLUSCONFIGURE_DELETE')",
-     *     message="No tienes permisos para eliminar tarjetas.",
-     *     redirectRoute="ps_controller_webpay_oneclick_cards_list"
-     * )
-     */
+    #[AdminSecurity(
+        "is_granted('ROLE_MOD_TAB_WEBPAYPLUSCONFIGURE_DELETE')",
+        message: "No tienes permisos para eliminar tarjetas.",
+        redirectRoute: "ps_controller_webpay_oneclick_cards_list"
+    )]
     public function deleteOneclickCardAction(
         string $cardId,
         string $customerId,
+        #[Autowire(service: 'security.csrf.token_manager')]
+        CsrfTokenManagerInterface $csrfTokenManager,
     ): RedirectResponse {
         $logger = TbkFactory::createLogger();
         try {
@@ -87,9 +88,7 @@ class OneclickCardsController extends FrameworkBundleAdminController
                     'customerId' => $customerId
                 ]);
 
-                $csrfToken = $this->container->get('security.csrf.token_manager')
-                    ->getToken('force_delete_' . $cardId)
-                    ->getValue();
+                $csrfToken = $csrfTokenManager->getToken('force_delete_' . $cardId)->getValue();
 
                 $this->addFlash('delete_failed', [
                     'cardId' => $cardId,
@@ -106,12 +105,11 @@ class OneclickCardsController extends FrameworkBundleAdminController
         return $this->redirectToRoute('ps_controller_webpay_oneclick_cards_list');
     }
 
-    /**
-     * @AdminSecurity(
-     *     "is_granted('ROLE_MOD_TAB_WEBPAYPLUSCONFIGURE_DELETE')",
-     *     redirectRoute="ps_controller_webpay_oneclick_cards_list"
-     * )
-     */
+
+    #[AdminSecurity(
+        "is_granted('ROLE_MOD_TAB_WEBPAYPLUSCONFIGURE_DELETE')",
+        redirectRoute: "ps_controller_webpay_oneclick_cards_list"
+    )]
     public function forceDeleteOneclickCardAction(
         string $cardId,
         string $customerId,

--- a/webpay/src/Controller/Admin/OneclickCardsController.php
+++ b/webpay/src/Controller/Admin/OneclickCardsController.php
@@ -17,6 +17,7 @@ use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Routing\Attribute\Route;
+use Transbank\Plugin\Helpers\PluginLogger;
 
 class OneclickCardsController extends PrestaShopAdminController
 {
@@ -56,55 +57,89 @@ class OneclickCardsController extends PrestaShopAdminController
     ): RedirectResponse {
         $logger = TbkFactory::createLogger();
         try {
-            $logger->logInfo("Iniciando eliminación de tarjeta Oneclick. ID Usuario: " . $customerId . ", ID Inscripción: " . $cardId);
-            $repository = new InscriptionRepository();
-            $inscription = $repository->getOneByUserIdAndInscriptionId($customerId, $cardId);
+            $logger->logInfo("Iniciando eliminación de tarjeta Oneclick. ID Usuario: $customerId, ID Inscripción: $cardId");
+            $inscription = $this->findInscription($cardId, $customerId, $logger);
 
             if (!$inscription) {
-                $this->addFlash('error', 'Inscripción no encontrada.');
-                $logger->logError("Inscripción no encontrada. ID Usuario: " . $customerId . ", ID Inscripción: " . $cardId);
                 return $this->redirectToRoute('ps_controller_webpay_oneclick_cards_list');
             }
 
-            $oneclickService = OneclickFactory::create();
+            $this->processOneclickDeletion($cardId, $customerId, $inscription, $csrfTokenManager, $logger);
 
-            try {
-                $oneclickService->delete($inscription['tbk_token'], $inscription['username']);
-                $logger->logInfo("Eliminación en Transbank exitosa. ID Usuario: " . $customerId . ", ID Inscripción: " . $cardId);
-                $deleted = $repository->deleteInscriptionByUserAndId($customerId, $cardId);
-
-                if (!$deleted) {
-                    $logger->logError("No se pudo eliminar la inscripción de la base de datos. ID Usuario: " . $customerId . ", ID Inscripción: " . $cardId);
-                    $this->addFlash('error', 'No se pudo eliminar la inscripción de la base de datos.');
-                    return $this->redirectToRoute('ps_controller_webpay_oneclick_cards_list');
-                }
-
-                $logger->logInfo("Tarjeta eliminada correctamente. ID Usuario: " . $customerId . ", ID Inscripción: " . $cardId);
-                $this->addFlash('success', 'Tarjeta eliminada correctamente.');
-            } catch (EcommerceException $e) {
-                $logger->logError("Error al eliminar la tarjeta en Transbank. ID Usuario:" . $customerId . ", ID Inscripción: " . $cardId . ", Error: " . $e->getMessage());
-                $forceDeleteUrl = $this->generateUrl('ps_controller_webpay_oneclick_card_force_delete', [
-                    'cardId' => $cardId,
-                    'customerId' => $customerId
-                ]);
-
-                $csrfToken = $csrfTokenManager->getToken('force_delete_' . $cardId)->getValue();
-
-                $this->addFlash('delete_failed', [
-                    'cardId' => $cardId,
-                    'customerId' => $customerId,
-                    'forceDeleteUrl' => $forceDeleteUrl,
-                    'csrfToken' => $csrfToken
-                ]);
-            }
         } catch (\Throwable $e) {
-            $logger->logError("Error inesperado al eliminar la tarjeta. ID Usuario: " . $customerId . ", ID Inscripción: " . $cardId . ", Error: " . $e->getMessage());
+            $logger->logError("Error inesperado al eliminar la tarjeta. ID Usuario: $customerId, ID Inscripción: $cardId, Error: " . $e->getMessage());
             $this->addFlash('error', 'Ocurrió un error al eliminar la inscripción.');
         }
 
         return $this->redirectToRoute('ps_controller_webpay_oneclick_cards_list');
     }
 
+    private function findInscription(string $cardId, string $customerId, PluginLogger $logger): ?array
+    {
+        $repository = new InscriptionRepository();
+        $inscription = $repository->getOneByUserIdAndInscriptionId($customerId, $cardId);
+
+        if (!$inscription) {
+            $this->addFlash('error', 'Inscripción no encontrada.');
+            $logger->logError("Inscripción no encontrada. ID Usuario: $customerId, ID Inscripción: $cardId");
+        }
+
+        return $inscription ?: null;
+    }
+
+    private function processOneclickDeletion(
+        string $cardId,
+        string $customerId,
+        array $inscription,
+        CsrfTokenManagerInterface $csrfTokenManager,
+        PluginLogger $logger
+    ): void {
+        $oneclickService = OneclickFactory::create();
+        $repository = new InscriptionRepository();
+
+        try {
+            $oneclickService->delete($inscription['tbk_token'], $inscription['username']);
+            $logger->logInfo("Eliminación en Transbank exitosa. ID Usuario: $customerId, ID Inscripción: $cardId");
+
+            $deleted = $repository->deleteInscriptionByUserAndId($customerId, $cardId);
+
+            if (!$deleted) {
+                $logger->logError("No se pudo eliminar la inscripción de la base de datos. ID Usuario: $customerId, ID Inscripción: $cardId");
+                $this->addFlash('error', 'No se pudo eliminar la inscripción de la base de datos.');
+                return;
+            }
+
+            $logger->logInfo("Tarjeta eliminada correctamente. ID Usuario: $customerId, ID Inscripción: $cardId");
+            $this->addFlash('success', 'Tarjeta eliminada correctamente.');
+
+        } catch (EcommerceException $e) {
+            $this->handleEcommerceException($cardId, $customerId, $csrfTokenManager, $logger, $e);
+        }
+    }
+
+    private function handleEcommerceException(
+        string $cardId,
+        string $customerId,
+        CsrfTokenManagerInterface $csrfTokenManager,
+        PluginLogger $logger,
+        EcommerceException $e
+    ): void {
+        $logger->logError("Error al eliminar la tarjeta en Transbank. ID Usuario: $customerId, ID Inscripción: $cardId, Error: " . $e->getMessage());
+
+        $forceDeleteUrl = $this->generateUrl('ps_controller_webpay_oneclick_card_force_delete', [
+            'cardId' => $cardId,
+            'customerId' => $customerId
+        ]);
+
+        $csrfToken = $csrfTokenManager->getToken('force_delete_' . $cardId)->getValue();
+
+        $this->addFlash('delete_failed', [
+            'cardId' => $cardId,
+            'customerId' => $customerId,
+            'forceDeleteUrl' => $forceDeleteUrl,
+            'csrfToken' => $csrfToken
+        ]);
+    }
 
     #[AdminSecurity(
         "is_granted('ROLE_MOD_TAB_WEBPAYPLUSCONFIGURE_DELETE')",

--- a/webpay/src/Controller/Admin/OneclickCardsController.php
+++ b/webpay/src/Controller/Admin/OneclickCardsController.php
@@ -16,7 +16,7 @@ use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
-use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Transbank\Plugin\Helpers\PluginLogger;
 
 class OneclickCardsController extends PrestaShopAdminController
@@ -26,7 +26,9 @@ class OneclickCardsController extends PrestaShopAdminController
         return ConfigureController::TAB_CLASS_NAME;
     }
 
-    #[Route("/webpay/oneclick-cards-list", name: "oneclick-cards-list")]
+    /**
+     * @Route("/webpay/oneclick-cards-list", name="oneclick-cards-list")
+     */
     #[AdminSecurity(
         "is_granted('ROLE_MOD_TAB_WEBPAYPLUSCONFIGURE_READ')",
         redirectRoute: "admin_login"
@@ -44,6 +46,13 @@ class OneclickCardsController extends PrestaShopAdminController
         ]);
     }
 
+    /**
+     * @Route(
+     *     "/webpay/oneclick-cards/{customerId}/{cardId}/delete",
+     *     name="ps_controller_webpay_oneclick_card_delete",
+     *     methods={"POST"}
+     * )
+     */
     #[AdminSecurity(
         "is_granted('ROLE_MOD_TAB_WEBPAYPLUSCONFIGURE_DELETE')",
         message: "No tienes permisos para eliminar tarjetas.",
@@ -65,7 +74,6 @@ class OneclickCardsController extends PrestaShopAdminController
             }
 
             $this->processOneclickDeletion($cardId, $customerId, $inscription, $csrfTokenManager, $logger);
-
         } catch (\Throwable $e) {
             $logger->logError("Error inesperado al eliminar la tarjeta. ID Usuario: $customerId, ID Inscripción: $cardId, Error: " . $e->getMessage());
             $this->addFlash('error', 'Ocurrió un error al eliminar la inscripción.');
@@ -111,7 +119,6 @@ class OneclickCardsController extends PrestaShopAdminController
 
             $logger->logInfo("Tarjeta eliminada correctamente. ID Usuario: $customerId, ID Inscripción: $cardId");
             $this->addFlash('success', 'Tarjeta eliminada correctamente.');
-
         } catch (EcommerceException $e) {
             $this->handleEcommerceException($cardId, $customerId, $csrfTokenManager, $logger, $e);
         }
@@ -141,6 +148,13 @@ class OneclickCardsController extends PrestaShopAdminController
         ]);
     }
 
+    /**
+     * @Route(
+     *     "/webpay/oneclick-cards/{customerId}/{cardId}/force-delete",
+     *     name="ps_controller_webpay_oneclick_card_force_delete",
+     *     methods={"POST"}
+     * )
+     */
     #[AdminSecurity(
         "is_granted('ROLE_MOD_TAB_WEBPAYPLUSCONFIGURE_DELETE')",
         redirectRoute: "ps_controller_webpay_oneclick_cards_list"

--- a/webpay/src/Form/OneclickType.php
+++ b/webpay/src/Form/OneclickType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;

--- a/webpay/src/Form/WebpayPlusType.php
+++ b/webpay/src/Form/WebpayPlusType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;

--- a/webpay/src/Grid/OneclickCards/OneclickCardGridDataFactory.php
+++ b/webpay/src/Grid/OneclickCards/OneclickCardGridDataFactory.php
@@ -22,8 +22,8 @@ final class OneclickCardGridDataFactory implements GridDataFactoryInterface
         $searchQueryBuilder = $this->queryBuilder->getSearchQueryBuilder($searchCriteria);
         $countQueryBuilder  = $this->queryBuilder->getCountQueryBuilder($searchCriteria);
 
-        $records = $searchQueryBuilder->execute()->fetchAllAssociative();
-        $recordsTotal = (int) $countQueryBuilder->execute()->fetchOne();
+        $records = $searchQueryBuilder->executeQuery()->fetchAllAssociative();
+        $recordsTotal = (int) $countQueryBuilder->executeQuery()->fetchOne();
 
         return new GridData(
             new RecordCollection($records),

--- a/webpay/src/Grid/OneclickCards/OneclickCardsFilters.php
+++ b/webpay/src/Grid/OneclickCards/OneclickCardsFilters.php
@@ -22,4 +22,16 @@ final class OneclickCardsFilters extends Filters
             'filters' => [],
         ];
     }
+
+    public function getOffset(): int
+    {
+        $defaults = self::getDefaults();
+        return $this->getInt('offset') ?? $defaults['offset'];
+    }
+
+    public function getLimit(): int
+    {
+        $defaults = self::getDefaults();
+        return $this->getInt('limit') ?? $defaults['limit'];
+    }
 }

--- a/webpay/src/Grid/TransactionsGridDefinitionFactory.php
+++ b/webpay/src/Grid/TransactionsGridDefinitionFactory.php
@@ -5,7 +5,7 @@ namespace PrestaShop\Module\WebpayPlus\Grid;
 use PrestaShop\Module\WebpayPlus\Grid\Column\Type\CustomLinkColumn;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractFilterableGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
@@ -16,7 +16,7 @@ use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\ColorColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ColorColumn;
 use PrestaShop\Module\WebpayPlus\Grid\TransactionsStatusChoiceProvider;
 
 

--- a/webpay/src/Helpers/TabsHelper.php
+++ b/webpay/src/Helpers/TabsHelper.php
@@ -1,7 +1,10 @@
 <?php
+
 namespace PrestaShop\Module\WebpayPlus\Helpers;
 
 use Tab;
+use PrestaShopBundle\Entity\Repository\TabRepository;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 class TabsHelper
 {
@@ -11,8 +14,8 @@ class TabsHelper
         $tab->active     = 1;
         $tab->class_name = $className;
         $tab->name       = $tabName;
-        $tab->id_parent = (int)Tab::getIdFromClassName($parentClassName);
-        $tab->module    = $moduleName;
+        $tab->id_parent  = (int) static::getTabIdFromClassName($parentClassName);
+        $tab->module     = $moduleName;
         if (!is_null($icon)) {
             $tab->icon = $icon;
         }
@@ -22,18 +25,23 @@ class TabsHelper
 
     public static function removeTab($className)
     {
-        $id_tab = (int)Tab::getIdFromClassName($className);
-        if ($id_tab == true){
-            $tab    = new Tab($id_tab);
+        $id_tab = (int) static::getTabIdFromClassName($className);
+        if ($id_tab) {
+            $tab = new Tab($id_tab);
             $tab->delete();
         }
-        /*
-        if ($tab->name !== '') {
-            $tab->delete();
-        }*/
-
         return true;
     }
 
-    
+    private static function getTabIdFromClassName(string $className): int
+    {
+        $container = SymfonyContainer::getInstance();
+
+        if ($container !== null) {
+            $tabRepository = $container->get(TabRepository::class);
+            return (int) $tabRepository->findOneIdByClassName($className);
+        }
+
+        return (int) Tab::getIdFromClassName($className);
+    }
 }

--- a/webpay/src/Utils/TransbankSdkOneclick.php
+++ b/webpay/src/Utils/TransbankSdkOneclick.php
@@ -45,8 +45,8 @@ class TransbankSdkOneclick
             );
         } else {
             $this->options = new Options(
-                Oneclick::DEFAULT_API_KEY,
-                Oneclick::DEFAULT_COMMERCE_CODE,
+                Oneclick::INTEGRATION_API_KEY,
+                Oneclick::INTEGRATION_COMMERCE_CODE,
                 $config['ENVIRONMENT']
             );
         }
@@ -153,7 +153,7 @@ class TransbankSdkOneclick
                 ', txDate: ' . $txDate . ', txTime: ' . $txTime);
             $resp = $this->inscription->delete($tbkUser, $userName);
             $this->log->logInfo('delete - resp: ' . json_encode($resp));
-            return $resp->wasSuccessfull();
+            return $resp;
         } catch (InscriptionDeleteException $e) {
             $errorMessage = "Error al eliminar la inscripción para =>
                 userName: {$userName}, tbkUser: {$tbkUser}, error: {$e->getMessage()}";

--- a/webpay/src/Utils/TransbankSdkWebpay.php
+++ b/webpay/src/Utils/TransbankSdkWebpay.php
@@ -42,8 +42,8 @@ class TransbankSdkWebpay
             );
         } else {
             $this->options = new Options(
-                WebpayPlus::DEFAULT_API_KEY,
-                WebpayPlus::DEFAULT_COMMERCE_CODE,
+                WebpayPlus::INTEGRATION_API_KEY,
+                WebpayPlus::INTEGRATION_COMMERCE_CODE,
                 $config['ENVIRONMENT']
             );
         }


### PR DESCRIPTION
**Description**

This update refines the module to add support for PrestaShop 9. It includes adjustments to the development container to align the local environment with PrestaShop 9, updates to the controller source code to follow PS9 standards and conventions, and documentation updates to reflect the new compatibility scope and development considerations. It also refines the technical requirements by setting PHP 8.2 as the minimum supported version.


**TEST**
`Install module`
<img width="400" height="400" alt="install module" src="https://github.com/user-attachments/assets/67c59592-a0fe-4ac2-9cd5-5917050f0e24" />

`Webpay flow`

https://github.com/user-attachments/assets/5f08cff0-3774-43d6-9ae4-a62fb88cafc3

`One click flow`


https://github.com/user-attachments/assets/9a822c11-e14b-4e8c-ba2f-f4a891d0de0d

`Admin`

https://github.com/user-attachments/assets/9611a6cd-ed16-4d98-b4f2-9744cdd5a5b2

