### PR TITLE
TBK 186 fix: filter invalid oneclick inscription records from subscription table

### DIFF
--- a/webpay/src/Grid/OneclickCards/OneclickCardQueryBuilder.php
+++ b/webpay/src/Grid/OneclickCards/OneclickCardQueryBuilder.php
@@ -5,6 +5,7 @@ namespace PrestaShop\Module\WebpayPlus\Grid\OneclickCards;
 use PrestaShop\PrestaShop\Core\Grid\Query\AbstractDoctrineQueryBuilder;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\Module\WebpayPlus\Config\OneclickConfig;
+use PrestaShop\Module\WebpayPlus\Model\TransbankInscriptions;
 
 final class OneclickCardQueryBuilder extends AbstractDoctrineQueryBuilder
 {
@@ -25,9 +26,10 @@ final class OneclickCardQueryBuilder extends AbstractDoctrineQueryBuilder
                 'ins.environment',
             ])
             ->from($this->dbPrefix . 'transbank_inscriptions', 'ins')
-            ->where('ins.finished = 1')
-            ->andWhere('ins.environment = :current_environment')
+            ->where('ins.environment = :current_environment')
             ->setParameter('current_environment', $currentEnvironment)
+            ->andWhere('ins.status = :status')
+            ->setParameter('status', TransbankInscriptions::STATUS_COMPLETED)
             ->leftJoin('ins', $this->dbPrefix . 'customer', 'c', 'c.id_customer = ins.user_id');
 
         $this->applyFilters($qb, $searchCriteria);


### PR DESCRIPTION
This change refines the logic used to build and render the Oneclick subscription table so that only valid and operable inscription records are displayed.

The update excludes failed, incomplete, or inconsistent inscription attempts that were previously shown in the grid and could lead to errors such as "subscription not found" during deletion.


**Test**
`Before`
<img width="1132" height="439" alt="ANTES" src="https://github.com/user-attachments/assets/b139365d-3b7c-4328-8309-092677db4d46" />

`After`
<img width="1118" height="411" alt="DESPUES" src="https://github.com/user-attachments/assets/2d327fc8-82fb-4d3e-921a-a9a0913497ea" />


