### PR TITLE
Tbk-209-fix: Refine uninstall and reset flows for PrestaShop 9 compatibility

### DIFF
--- a/webpay/config/services.yml
+++ b/webpay/config/services.yml
@@ -2,6 +2,14 @@ services:
   _defaults:
     public: true
 
+  # Repository Services
+  webpay.repository.tab_repository:
+    class: PrestaShopBundle\Entity\Repository\TabRepository
+    factory: ["@doctrine.orm.entity_manager", "getRepository"]
+    arguments:
+      - 'PrestaShopBundle\Entity\Tab'
+    public: true
+
   # Shared services for Webpay and Oneclick forms
   webpay.form.common_webpay_fields:
     class: 'PrestaShop\Module\WebpayPlus\Form\CommonWebpayFields'

--- a/webpay/config/services.yml
+++ b/webpay/config/services.yml
@@ -3,12 +3,7 @@ services:
     public: true
 
   # Repository Services
-  webpay.repository.tab_repository:
-    class: PrestaShopBundle\Entity\Repository\TabRepository
-    factory: ["@doctrine.orm.entity_manager", "getRepository"]
-    arguments:
-      - 'PrestaShopBundle\Entity\Tab'
-    public: true
+  webpay.repository.tab_repository: '@PrestaShopBundle\Entity\Repository\TabRepository'
 
   # Shared services for Webpay and Oneclick forms
   webpay.form.common_webpay_fields:

--- a/webpay/src/Helpers/TabsHelper.php
+++ b/webpay/src/Helpers/TabsHelper.php
@@ -38,7 +38,7 @@ class TabsHelper
         $container = SymfonyContainer::getInstance();
 
         if ($container !== null) {
-            $tabRepository = $container->get(TabRepository::class);
+            $tabRepository = $container->get('webpay.repository.tab_repository');
             return (int) $tabRepository->findOneIdByClassName($className);
         }
 

--- a/webpay/src/Helpers/TabsHelper.php
+++ b/webpay/src/Helpers/TabsHelper.php
@@ -37,7 +37,7 @@ class TabsHelper
     {
         $container = SymfonyContainer::getInstance();
 
-        if ($container !== null) {
+        if ($container !== null && $container->has('webpay.repository.tab_repository')) {
             $tabRepository = $container->get('webpay.repository.tab_repository');
             return (int) $tabRepository->findOneIdByClassName($className);
         }

--- a/webpay/webpay.php
+++ b/webpay/webpay.php
@@ -44,7 +44,7 @@ class WebPay extends PaymentModule
         $this->displayName = 'Webpay Plus';
         $this->description = 'Recibe pagos en línea con tarjetas de crédito y Redcompra en tu Prestashop a través de Webpay Plus y Oneclick';
         $this->confirmUninstall = '¿Estás seguro/a que deseas desinstalar este módulo de pago?';
-        $this->ps_versions_compliancy = array('min' => '1.7.6.0', 'max' => _PS_VERSION_);
+        $this->ps_versions_compliancy = array('min' => '9.0.0', 'max' => _PS_VERSION_);
         $this->pluginValidation();
         $this->log = TbkFactory::createLogger();
     }


### PR DESCRIPTION
## Description

This PR refines the module reset and uninstall flows for PrestaShop 9.

The current implementation was reviewed to detect operations causing errors during lifecycle actions such as reset or removal. 

What this PR includes is:

The loading of the repositories that was blocking the reset and uninstall operations was refined.

Additionally, the minimum supported PrestaShop version of the plugin was adjusted.

The lifecycle was also validated to ensure the module can be reset, uninstalled, and installed again in PrestaShop 9 without unexpected interruptions.


### Evidence

`After`

`reset`
<img width="1015" height="120" alt="image" src="https://github.com/user-attachments/assets/db6046c4-a2c0-476a-9d6b-c3a77fab3052" />

`uninstall`
<img width="801" height="96" alt="image" src="https://github.com/user-attachments/assets/e3be77e1-ba4d-4f14-8e3a-3064404caff2" />



`Before`

`reset`
<img width="463" height="57" alt="image" src="https://github.com/user-attachments/assets/3544c674-def5-45a6-9e0c-3d2648054979" />

`uninstall`
<img width="486" height="56" alt="image" src="https://github.com/user-attachments/assets/ec9229e2-2c81-4f2b-b49e-138674cae78e" />



