### PR TITLE
chore: update publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: write
     name: Build the plugin with PHP 8.2 and upload binaries
     steps:
       - name: 1. Checkout code
@@ -16,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: 2. Setup php and composer
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f
         with:
           php-version: "8.2"
       


### PR DESCRIPTION
Refines the publish pipeline by pinning the setup-php action to a specific commit hash and adjusting workflow permissions

**Evidence**

<img width="854" height="293" alt="image" src="https://github.com/user-attachments/assets/e31728d4-2a96-4d23-aac3-b788ab4ff0e8" />
