### PR TITLE
chore: consolidate run instructions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,18 +16,17 @@ RUN apt-get update && apt-get install -y \
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 
-RUN ln -snf /usr/share/zoneinfo/America/Santiago /etc/localtime \
+RUN set -eux; \
+    ln -snf /usr/share/zoneinfo/America/Santiago /etc/localtime \
  && echo "America/Santiago" > /etc/timezone \
- && echo "date.timezone = America/Santiago" > /usr/local/etc/php/conf.d/00-timezone.ini
-
-RUN printf '%s\n' \
+ && echo "date.timezone = America/Santiago" > /usr/local/etc/php/conf.d/00-timezone.ini \
+ && printf '%s\n' \
   'log_errors=On' \
   'error_reporting=E_ALL' \
   'display_errors=Off' \
   'error_log=/var/log/apache2/php-error.log' \
-  > /usr/local/etc/php/conf.d/99-logging.ini
-
-RUN echo "ServerName localhost" > /etc/apache2/conf-available/servername.conf \
+  > /usr/local/etc/php/conf.d/99-logging.ini \
+ && echo "ServerName localhost" > /etc/apache2/conf-available/servername.conf \
  && a2enconf servername
 
 WORKDIR /workspace


### PR DESCRIPTION
Merge three separate RUN instructions into a single layer to reduce image size and improve build performance. Add 'set -eux' for better error detection and debugging during the build process.