### PR TITLE
feat: refine webpay return

### DIFF
--- a/.github/workflows/kiuwan.yml
+++ b/.github/workflows/kiuwan.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   scan:
-    uses: TransbankDevelopers/transbank-github-actions-templates/.github/workflows/kiuwan-pr-scan.yml@2a2837602d7636c5f31f97209ae60a0fe74c2c94
+    uses: TransbankDevelopers/transbank-github-actions-templates/.github/workflows/kiuwan-pr-scan.yml@02f92d3b1c1b56c6242aa7c76eb9479fd82187aa
     with:
       project_name: td-webpay-plugin-prestashop
       source_path: .

--- a/webpay/controllers/front/webpaypluspaymentvalidate.php
+++ b/webpay/controllers/front/webpaypluspaymentvalidate.php
@@ -2,12 +2,14 @@
 
 use PrestaShop\Module\WebpayPlus\Config\WebpayConfig;
 use PrestaShop\Module\WebpayPlus\Controller\PaymentModuleFrontController;
+use PrestaShop\Module\WebpayPlus\Exceptions\MariaDbNamedLockException;
 use PrestaShop\Module\WebpayPlus\Helpers\WebpayPlusFactory;
 use Transbank\Webpay\WebpayPlus\Responses\TransactionCommitResponse;
 use PrestaShop\Module\WebpayPlus\Model\TransbankWebpayRestTransaction;
 use PrestaShop\Module\WebpayPlus\Helpers\TbkFactory;
 use Transbank\Plugin\Exceptions\EcommerceException;
 use PrestaShop\Module\WebpayPlus\Repository\TransactionRepository;
+use PrestaShop\Module\WebpayPlus\Infrastructure\Lock\MariaDbNamedLock;
 
 /**
  * This class handles the validation of payment responses from the Webpay Plus payment gateway.
@@ -28,8 +30,10 @@ class WebPayWebpayplusPaymentValidateModuleFrontController extends PaymentModule
     const WEBPAY_ERROR_FLOW_MESSAGE = 'Orden cancelada por un error en el formulario de pago. Por favor, reintente el pago.';
     const WEBPAY_EXCEPTION_FLOW_MESSAGE = 'No se pudo procesar el pago. Si el problema persiste, contacte al comercio.';
     const WEBPAY_CART_MANIPULATED_MESSAGE = "El monto del carro ha cambiado mientras se procesaba el pago, la transacción fue cancelada. Ningún cobro fue realizado.";
+    const WEBPAY_OPERATION_IN_PROGRESS_MESSAGE = 'Ya estamos procesando tu solicitud. Por favor, espera unos momentos antes de volver a intentarlo.';
 
     protected $responseData = [];
+    protected MariaDbNamedLock $webpayReturnLock;
 
     /** @var TransactionRepository */
     private $repository;
@@ -42,6 +46,7 @@ class WebPayWebpayplusPaymentValidateModuleFrontController extends PaymentModule
         parent::__construct();
         $this->logger = TbkFactory::createLogger();
         $this->repository = new TransactionRepository();
+        $this->webpayReturnLock = new MariaDbNamedLock();
     }
 
     /**
@@ -144,32 +149,85 @@ class WebPayWebpayplusPaymentValidateModuleFrontController extends PaymentModule
      */
     private function handleNormalFlow(string $token): void
     {
+        $lockAcquired = false;
         $this->logInfo("Procesando transacción por flujo Normal => token: {$token}");
 
-        if ($this->checkTransactionIsAlreadyProcessed($token)) {
-            $this->handleTransactionAlreadyProcessed($token);
+        try {
+            $lockAcquired = $this->acquireWebpayReturnLock($token);
+
+            if (!$lockAcquired) {
+                $this->setPaymentErrorPage(self::WEBPAY_OPERATION_IN_PROGRESS_MESSAGE);
+                return;
+            }
+
+            if ($this->checkTransactionIsAlreadyProcessed($token)) {
+                $this->handleTransactionAlreadyProcessed($token);
+                return;
+            }
+
+            $webpayTransaction = $this->repository->getTransactionWebpayByToken($token);
+            $cart = $this->getCart($webpayTransaction->cart_id);
+
+            if ($webpayTransaction->amount != $this->getOrderTotalRound($cart)) {
+                $this->handleCartManipulated($webpayTransaction);
+                return;
+            }
+
+            $transbankSdk = WebpayPlusFactory::create();
+            $commitResponse = $transbankSdk->commitTransaction($token);
+
+            if ($commitResponse->isApproved()) {
+                $this->handleAuthorizedTransaction(
+                    $cart,
+                    $webpayTransaction,
+                    $commitResponse
+                );
+            } else {
+                $this->handleUnauthorizedTransaction($webpayTransaction, $commitResponse);
+            }
+        } finally {
+            $this->releaseWebpayReturnLock($token, $lockAcquired);
+        }
+    }
+
+    /**
+     * Tries to acquire the return lock for a token.
+     *
+     * @param string $token
+     * @return bool True when the lock is acquired, false when another request is already processing.
+     */
+    private function acquireWebpayReturnLock(string $token): bool
+    {
+        $lockAcquired = $this->webpayReturnLock->acquire($token);
+
+        if (!$lockAcquired) {
+            $this->logInfo("Retorno de Webpay ya se encuentra en procesamiento => token: {$token}");
+        }
+
+        return $lockAcquired;
+    }
+
+    /**
+     * Releases the return lock only when it was actually acquired.
+     *
+     * @param string $token
+     * @param bool $lockAcquired
+     * @return void
+     */
+    private function releaseWebpayReturnLock(string $token, bool $lockAcquired): void
+    {
+        if (!$lockAcquired) {
             return;
         }
 
-        $webpayTransaction = $this->repository->getTransactionWebpayByToken($token);
-        $cart = $this->getCart($webpayTransaction->cart_id);
+        try {
+            $released = $this->webpayReturnLock->release($token);
 
-        if ($webpayTransaction->amount != $this->getOrderTotalRound($cart)) {
-            $this->handleCartManipulated($webpayTransaction);
-            return;
-        }
-
-        $transbankSdk = WebpayPlusFactory::create();
-        $commitResponse = $transbankSdk->commitTransaction($token);
-
-        if ($commitResponse->isApproved()) {
-            $this->handleAuthorizedTransaction(
-                $cart,
-                $webpayTransaction,
-                $commitResponse
-            );
-        } else {
-            $this->handleUnauthorizedTransaction($webpayTransaction, $commitResponse);
+            if (!$released) {
+                $this->logWarning("No se pudo liberar el lock de retorno de Webpay token => {$token}");
+            }
+        } catch (MariaDbNamedLockException $e) {
+            $this->logWarning("Error al liberar el lock de retorno de Webpay token => {$token} - Error: {$e->getMessage()}");
         }
     }
 

--- a/webpay/controllers/front/webpaypluspaymentvalidate.php
+++ b/webpay/controllers/front/webpaypluspaymentvalidate.php
@@ -4,12 +4,12 @@ use PrestaShop\Module\WebpayPlus\Config\WebpayConfig;
 use PrestaShop\Module\WebpayPlus\Controller\PaymentModuleFrontController;
 use PrestaShop\Module\WebpayPlus\Exceptions\MariaDbNamedLockException;
 use PrestaShop\Module\WebpayPlus\Helpers\WebpayPlusFactory;
+use PrestaShop\Module\WebpayPlus\Infrastructure\Lock\MariaDbNamedLock;
 use Transbank\Webpay\WebpayPlus\Responses\TransactionCommitResponse;
 use PrestaShop\Module\WebpayPlus\Model\TransbankWebpayRestTransaction;
 use PrestaShop\Module\WebpayPlus\Helpers\TbkFactory;
 use Transbank\Plugin\Exceptions\EcommerceException;
 use PrestaShop\Module\WebpayPlus\Repository\TransactionRepository;
-use PrestaShop\Module\WebpayPlus\Infrastructure\Lock\MariaDbNamedLock;
 
 /**
  * This class handles the validation of payment responses from the Webpay Plus payment gateway.

--- a/webpay/controllers/front/webpaypluspaymentvalidate.php
+++ b/webpay/controllers/front/webpaypluspaymentvalidate.php
@@ -2,7 +2,6 @@
 
 use PrestaShop\Module\WebpayPlus\Config\WebpayConfig;
 use PrestaShop\Module\WebpayPlus\Controller\PaymentModuleFrontController;
-use PrestaShop\Module\WebpayPlus\Exceptions\MariaDbNamedLockException;
 use PrestaShop\Module\WebpayPlus\Helpers\WebpayPlusFactory;
 use PrestaShop\Module\WebpayPlus\Infrastructure\Lock\MariaDbNamedLock;
 use Transbank\Webpay\WebpayPlus\Responses\TransactionCommitResponse;
@@ -198,10 +197,16 @@ class WebPayWebpayplusPaymentValidateModuleFrontController extends PaymentModule
      */
     private function acquireWebpayReturnLock(string $token): bool
     {
-        $lockAcquired = $this->webpayReturnLock->acquire($token);
+        $lockAcquired = false;
 
-        if (!$lockAcquired) {
-            $this->logInfo("Retorno de Webpay ya se encuentra en procesamiento => token: {$token}");
+        try {
+            $lockAcquired = $this->webpayReturnLock->acquire($token);
+
+            if (!$lockAcquired) {
+                $this->logInfo("Retorno de Webpay ya se encuentra en procesamiento => token: {$token}");
+            }
+        } catch (\Throwable $e) {
+            $this->logError("Error al adquirir el lock de retorno de Webpay token => {$token} - Error: {$e->getMessage()}");
         }
 
         return $lockAcquired;
@@ -226,7 +231,7 @@ class WebPayWebpayplusPaymentValidateModuleFrontController extends PaymentModule
             if (!$released) {
                 $this->logWarning("No se pudo liberar el lock de retorno de Webpay token => {$token}");
             }
-        } catch (MariaDbNamedLockException $e) {
+        } catch (\Throwable $e) {
             $this->logWarning("Error al liberar el lock de retorno de Webpay token => {$token} - Error: {$e->getMessage()}");
         }
     }

--- a/webpay/shared/Helpers/ILogger.php
+++ b/webpay/shared/Helpers/ILogger.php
@@ -8,4 +8,5 @@ interface ILogger {
     function logDebug($str);
     function getInfo();
     function getLogDetail($filename);
+    function logWarning($str);
 }

--- a/webpay/shared/Helpers/PluginLogger.php
+++ b/webpay/shared/Helpers/PluginLogger.php
@@ -55,6 +55,11 @@ final class PluginLogger implements ILogger {
         $this->logger->error($msg);
     }
 
+    public function logWarning($msg)
+    {
+        $this->logger->warning($msg);
+    }
+
     public function getInfo()
     {
         $files = glob($this->config->getLogDir().'/*.log');

--- a/webpay/src/Controller/BaseModuleFrontController.php
+++ b/webpay/src/Controller/BaseModuleFrontController.php
@@ -53,6 +53,11 @@ class BaseModuleFrontController extends ModuleFrontController
         $this->logger->logInfo($msg);
     }
 
+    protected function logWarning(string $msg)
+    {
+        $this->logger->logWarning($msg);
+    }
+
     protected function cartToLog($cart)
     {
         $this->logInfo('-----------------------------------------------------');

--- a/webpay/src/Exceptions/MariaDbNamedLockException.php
+++ b/webpay/src/Exceptions/MariaDbNamedLockException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PrestaShop\Module\WebpayPlus\Exceptions;
+
+use RuntimeException;
+
+class MariaDbNamedLockException extends RuntimeException {}

--- a/webpay/src/Infrastructure/Lock/MariaDbNamedLock.php
+++ b/webpay/src/Infrastructure/Lock/MariaDbNamedLock.php
@@ -21,7 +21,7 @@ class MariaDbNamedLock
         $query = "SELECT GET_LOCK('$escapedLockName', 0)";
         $result = Db::getInstance()->getValue($query);
 
-        if ($result === null || $result === false) {
+        if ($result === null) {
             throw new MariaDbNamedLockException(
                 'No se pudo adquirir el lock de retorno de Webpay: error al consultar MariaDB.'
             );
@@ -37,7 +37,7 @@ class MariaDbNamedLock
         $query = "SELECT RELEASE_LOCK('$escapedLockName')";
         $result = Db::getInstance()->getValue($query);
 
-        if ($result === null || $result === false) {
+        if ($result === null) {
             throw new MariaDbNamedLockException(
                 'No se pudo liberar el lock de retorno de Webpay: error al consultar MariaDB.'
             );

--- a/webpay/src/Infrastructure/Lock/MariaDbNamedLock.php
+++ b/webpay/src/Infrastructure/Lock/MariaDbNamedLock.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PrestaShop\Module\WebpayPlus\Infrastructure\Lock;
+
+use Db;
+use PrestaShop\Module\WebpayPlus\Exceptions\MariaDbNamedLockException;
+
+/**
+ * Thin MariaDB named lock adapter.
+ *
+ * It provides a reusable acquire/release primitive for flows that need to serialize work by key.
+ */
+class MariaDbNamedLock
+{
+    private const LOCK_PREFIX = 'transbank_webpay_lock_';
+
+    public function acquire(string $key): bool
+    {
+        $lockName = $this->buildLockName($key);
+        $escapedLockName = pSQL($lockName);
+        $query = "SELECT GET_LOCK('$escapedLockName', 0)";
+        $result = Db::getInstance()->getValue($query);
+
+        if ($result === null || $result === false) {
+            throw new MariaDbNamedLockException(
+                'No se pudo adquirir el lock de retorno de Webpay: error al consultar MariaDB.'
+            );
+        }
+
+        return $result === 1;
+    }
+
+    public function release(string $key): bool
+    {
+        $lockName = $this->buildLockName($key);
+        $escapedLockName = pSQL($lockName);
+        $query = "SELECT RELEASE_LOCK('$escapedLockName')";
+        $result = Db::getInstance()->getValue($query);
+
+        if ($result === null || $result === false) {
+            throw new MariaDbNamedLockException(
+                'No se pudo liberar el lock de retorno de Webpay: error al consultar MariaDB.'
+            );
+        }
+
+        return $result === 1;
+    }
+
+    private function buildLockName(string $key): string
+    {
+        return self::LOCK_PREFIX . substr(hash('sha256', $key), 0, 40);
+    }
+}


### PR DESCRIPTION
This PR refines the Webpay commit workflow to safely handle concurrent return requests.

When Webpay sends multiple return calls for the same transaction, only the first request is allowed to continue through the normal commit flow. Any concurrent duplicate requests are intentionally aborted early by a lock to prevent double processing.

This is expected behavior: the user only sees the first return flow, while the other requests occur backend-to-backend and should be ignored once processing is already in progress.

If the first request acquires the lock but later fails, the error is handled through the normal error flow. This keeps the control flow consistent and lets the existing error handling mechanisms decide the final outcome.

The change helps prevent race conditions, duplicate commits, and inconsistent payment states.

## Test

- Success
<img width="2538" height="1272" alt="Success" src="https://github.com/user-attachments/assets/7ff7c8d1-ab3f-497e-9764-3910d9d16f06" />

- Error
<img width="2538" height="1272" alt="Error" src="https://github.com/user-attachments/assets/dc0e5406-fd66-4e16-aff4-e124c1898235" />