### PR TITLE
TBK-424 feat: add log sanitization

### DIFF
--- a/webpay/shared/Helpers/PluginLogger.php
+++ b/webpay/shared/Helpers/PluginLogger.php
@@ -114,8 +114,8 @@ final class PluginLogger implements ILogger {
     }
 
     /**
-     * Strips markup and normalizes line breaks before writing to the log, preventing
-     * markup injection and forged log lines from unauthenticated data.
+     * Strips markup and normalizes line breaks before writing to the log,
+     * preventing markup injection.
      *
      * @param mixed $msg The raw message to sanitize before logging.
      * @return string

--- a/webpay/shared/Helpers/PluginLogger.php
+++ b/webpay/shared/Helpers/PluginLogger.php
@@ -42,22 +42,22 @@ final class PluginLogger implements ILogger {
 
     public function logDebug($msg)
     {
-        $this->logger->debug($msg);
+        $this->logger->debug($this->sanitizeMessage($msg));
     }
 
     public function logInfo($msg)
     {
-        $this->logger->info($msg);
+        $this->logger->info($this->sanitizeMessage($msg));
     }
 
     public function logError($msg)
     {
-        $this->logger->error($msg);
+        $this->logger->error($this->sanitizeMessage($msg));
     }
 
     public function logWarning($msg)
     {
-        $this->logger->warning($msg);
+        $this->logger->warning($this->sanitizeMessage($msg));
     }
 
     public function getInfo()
@@ -111,5 +111,20 @@ final class PluginLogger implements ILogger {
             }
         }
         return $bytes;
+    }
+
+    /**
+     * Strips markup and normalizes line breaks before writing to the log, preventing
+     * markup injection and forged log lines from unauthenticated data.
+     *
+     * @param mixed $msg The raw message to sanitize before logging.
+     * @return string
+     */
+    private function sanitizeMessage($msg): string
+    {
+        $msg = strip_tags((string) $msg);
+        $msg = preg_replace('/[\r\n]+/', ' ', $msg);
+
+        return trim($msg);
     }
 }


### PR DESCRIPTION
## Description
Log entries in this module can include values that originate from unauthenticated, external requests, for example parameters received on the payment gateway's return/callback endpoints. This change normalizes every message before it's persisted to the log, so log content stays plain text and consistent regardless of where the underlying value came from. This mirrors the same log-writing standard already applied across the other Transbank e-commerce plugins.

## Changes
- webpay/shared/Helpers/PluginLogger.php: added a private sanitizeMessage() method that strips HTML tags and collapses line breaks into single spaces. Applied it inside logDebug(), logInfo(), logError(), and logWarning(), right before the message is handed to the underlying Monolog handler, so every log call site in the module is covered without needing individual changes elsewhere.

## Tests
- Before
<img width="1600" height="803" alt="Before" src="https://github.com/user-attachments/assets/0a024ffa-d6d7-4070-8031-c21bab5b61ef" />

- After
<img width="2540" height="1280" alt="After" src="https://github.com/user-attachments/assets/51d84b1d-7766-4ad5-a510-6a18e298b30a" />
